### PR TITLE
Fix package URLs to point to correct repository

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Petabridge</Authors>
     <Company>Petabridge</Company>
     <Product>SkillServer</Product>
-    <PackageProjectUrl>https://github.com/Aaronontheweb/netclaw</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Aaronontheweb/netclaw</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/netclaw-dev/skill-server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/netclaw-dev/skill-server</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>agent-skills;ai;skills;skill-server;netclaw</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
Fix PackageProjectUrl and RepositoryUrl in Directory.Build.props to point to the correct repository (netclaw-dev/skill-server instead of Aaronontheweb/netclaw).

## Test plan
- [x] Build passes