### PR TITLE
Add API key authentication for write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Configuration is via environment variables or `appsettings.json`:
 |----------|---------|-------------|
 | `SKILLSERVER__DATAPATH` | `./data` | Directory for SQLite database and blobs |
 | `SKILLSERVER__BASEURL` | `http://localhost:8080` | Base URL for generating absolute URLs in indexes |
+| `SKILLSERVER__APIKEY` | *(none)* | Initial API key, seeded on first run if no keys exist in DB |
 
 ## API Endpoints
 
@@ -58,8 +59,8 @@ Configuration is via environment variables or `appsettings.json`:
 | `GET /skills/{name}/{version}` | Get specific version metadata |
 | `GET /skills/{name}/{version}/SKILL.md` | Download SKILL.md |
 | `GET /skills/{name}/{version}/{path}` | Download resource file |
-| `POST /skills` | Upload new skill version (multipart/form-data) |
-| `DELETE /skills/{name}/{version}` | Delete version |
+| `POST /skills` | Upload new skill version (multipart/form-data) 🔑 |
+| `DELETE /skills/{name}/{version}` | Delete version 🔑 |
 
 ### Blobs
 
@@ -67,6 +68,16 @@ Configuration is via environment variables or `appsettings.json`:
 |----------|-------------|
 | `GET /blobs/sha256/{digest}` | Download blob by digest |
 | `HEAD /blobs/sha256/{digest}` | Check if blob exists |
+
+### API Keys
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /api-keys` | Create a new API key 🔑 |
+| `GET /api-keys` | List all API keys (without secrets) 🔑 |
+| `DELETE /api-keys/{id}` | Revoke an API key 🔑 |
+
+🔑 = Requires `Authorization: Bearer <key>` header (when API keys are configured)
 
 ### Health
 
@@ -80,6 +91,7 @@ Upload a SKILL.md file:
 
 ```bash
 curl -X POST http://localhost:8080/skills \
+  -H "Authorization: Bearer sk-your-api-key" \
   -F "name=my-skill" \
   -F "version=1.0.0" \
   -F "category=internal" \
@@ -99,11 +111,15 @@ Usage:
 ```csharp
 using Netclaw.SkillClient;
 
-// Direct instantiation
+// Direct instantiation (read-only, no auth needed)
 using var client = new SkillServerClient("http://localhost:8080");
+
+// With API key for write operations
+using var authClient = new SkillServerClient("http://localhost:8080", apiKey: "sk-your-api-key");
 
 // Or via DI
 services.AddSkillServerClient("http://localhost:8080");
+services.AddSkillServerClient("http://localhost:8080", "sk-your-api-key");
 
 // Get RFC index
 var index = await client.GetRfcIndexAsync();
@@ -161,10 +177,51 @@ dotnet publish src/SkillServer -c Release /t:PublishContainer
 
 ## Security
 
-For v1, authentication is **not built in**. Deploy behind your firewall or reverse proxy with authentication.
+SkillServer uses **API key authentication** to protect write operations. Read and discovery endpoints remain open so agents can fetch skills without credentials.
 
-Future versions will add:
-- API key authentication
+### How It Works
+
+- API keys are SHA-256 hashed before storage — raw keys are never persisted
+- Keys are compared using constant-time comparison to prevent timing attacks
+- Keys use the format `sk-{random}` (256 bits of entropy, base64url-encoded)
+- Raw keys are shown **only once** at creation time and cannot be recovered
+
+### Bootstrap
+
+Set the `SKILLSERVER__APIKEY` environment variable before first run:
+
+```bash
+SKILLSERVER__APIKEY=sk-my-secret-key dotnet run --project src/SkillServer
+```
+
+The server hashes and stores this as a "bootstrap" key on first startup. Once any key exists in the database, the environment variable is ignored on subsequent starts.
+
+### Managing Keys
+
+All key management endpoints require an existing valid API key:
+
+```bash
+# Create a new key
+curl -X POST http://localhost:8080/api-keys \
+  -H "Authorization: Bearer sk-your-existing-key" \
+  -H "Content-Type: application/json" \
+  -d '{"label": "ci-deploy"}'
+
+# List keys (never shows raw key or hash)
+curl http://localhost:8080/api-keys \
+  -H "Authorization: Bearer sk-your-existing-key"
+
+# Revoke a key (cannot delete the last remaining key)
+curl -X DELETE http://localhost:8080/api-keys/2 \
+  -H "Authorization: Bearer sk-your-existing-key"
+```
+
+### Backwards Compatibility
+
+When no API keys exist in the database, authentication is disabled and all endpoints are open. This preserves the original v1 behavior for existing deployments.
+
+### Future Enhancements
+
 - Rate limiting
 - Audit logging
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - SKILLSERVER__DATAPATH=/data
       - SKILLSERVER__BASEURL=http://localhost:8080
+      - SKILLSERVER__APIKEY=${SKILLSERVER_APIKEY:-}
       - ASPNETCORE_URLS=http://+:8080
 
 volumes:

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -54,7 +54,7 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 
 ## Design Constraints
 
-1. **No authentication in v1** - Deploy behind firewall/reverse proxy
+1. **API key authentication** - SHA-256 hashed keys, write-only protection, reads stay open
 2. **AOT-ready** - No reflection-based serialization
 3. **Single-file deployment** - SQLite, no external dependencies
 4. **Multi-arch containers** - linux-x64, linux-arm64
@@ -77,7 +77,6 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 
 ## Future Roadmap
 
-- API key authentication
 - Rate limiting
 - Audit logging
 - Webhook notifications

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -90,6 +90,7 @@ docker compose -f docker/docker-compose.yml up -d
 |----------|---------|---------|
 | `SKILLSERVER__DATAPATH` | `./data` | SQLite + blob storage path |
 | `SKILLSERVER__BASEURL` | `http://localhost:8080` | Base URL for absolute links |
+| `SKILLSERVER__APIKEY` | *(none)* | Initial API key (seeded on first run if no keys exist) |
 
 ## IDE Configuration
 

--- a/src/Netclaw.SkillClient/Models.cs
+++ b/src/Netclaw.SkillClient/Models.cs
@@ -121,6 +121,54 @@ public sealed record SkillVersionSummary
     public int FileCount { get; init; }
 }
 
+public sealed record SkillUploadResponse
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = "";
+
+    [JsonPropertyName("sha256")]
+    public string Sha256 { get; init; } = "";
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = "";
+}
+
+public sealed record CreateApiKeyResponse
+{
+    [JsonPropertyName("id")]
+    public long Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; init; } = "";
+
+    [JsonPropertyName("key")]
+    public string Key { get; init; } = "";
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+public sealed record ApiKeySummary
+{
+    [JsonPropertyName("id")]
+    public long Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; init; } = "";
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
 /// <summary>
 /// JSON serialization context for AOT support.
 /// </summary>
@@ -128,5 +176,9 @@ public sealed record SkillVersionSummary
 [JsonSerializable(typeof(IReadOnlyList<SkillSummary>))]
 [JsonSerializable(typeof(IReadOnlyList<SkillVersionSummary>))]
 [JsonSerializable(typeof(SkillVersionSummary))]
+[JsonSerializable(typeof(SkillUploadResponse))]
+[JsonSerializable(typeof(CreateApiKeyResponse))]
+[JsonSerializable(typeof(ApiKeySummary))]
+[JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 public partial class SkillServerClientJsonContext : JsonSerializerContext;

--- a/src/Netclaw.SkillClient/ServiceCollectionExtensions.cs
+++ b/src/Netclaw.SkillClient/ServiceCollectionExtensions.cs
@@ -12,16 +12,27 @@ namespace Netclaw.SkillClient;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// Adds SkillServerClient to the service collection.
-    /// </summary>
     public static IServiceCollection AddSkillServerClient(
         this IServiceCollection services,
         string serverUrl)
     {
+        return services.AddSkillServerClient(serverUrl, apiKey: null);
+    }
+
+    /// <summary>
+    /// Adds SkillServerClient to the service collection with an API key.
+    /// </summary>
+    public static IServiceCollection AddSkillServerClient(
+        this IServiceCollection services,
+        string serverUrl,
+        string? apiKey)
+    {
         services.AddHttpClient<SkillServerClient>(client =>
         {
             client.BaseAddress = new Uri(serverUrl.TrimEnd('/') + "/");
+            if (!string.IsNullOrEmpty(apiKey))
+                client.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
         });
 
         return services;

--- a/src/Netclaw.SkillClient/SkillServerClient.cs
+++ b/src/Netclaw.SkillClient/SkillServerClient.cs
@@ -18,10 +18,13 @@ public sealed class SkillServerClient : IDisposable
     private readonly bool _ownsHttpClient;
     private readonly JsonSerializerOptions _jsonOptions;
 
-    public SkillServerClient(string serverUrl)
+    public SkillServerClient(string serverUrl, string? apiKey = null)
     {
         _httpClient = new HttpClient { BaseAddress = new Uri(serverUrl.TrimEnd('/') + "/") };
         _ownsHttpClient = true;
+        if (!string.IsNullOrEmpty(apiKey))
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
         _jsonOptions = new JsonSerializerOptions
         {
             TypeInfoResolver = SkillServerClientJsonContext.Default
@@ -146,6 +149,30 @@ public sealed class SkillServerClient : IDisposable
         var actualHex = Convert.ToHexString(hashBytes).ToLowerInvariant();
 
         return actualHex == expectedHex;
+    }
+
+    public async Task<SkillUploadResponse> UploadSkillAsync(
+        string name, string version, Stream skillMdContent, string? category = null,
+        CancellationToken ct = default)
+    {
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent(name), "name");
+        content.Add(new StringContent(version), "version");
+        if (category is not null)
+            content.Add(new StringContent(category), "category");
+        content.Add(new StreamContent(skillMdContent), "file", "SKILL.md");
+
+        var response = await _httpClient.PostAsync("skills", content, ct);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync(
+            SkillServerClientJsonContext.Default.SkillUploadResponse, ct))!;
+    }
+
+    public async Task DeleteVersionAsync(string name, string version, CancellationToken ct = default)
+    {
+        var response = await _httpClient.DeleteAsync(
+            $"skills/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}", ct);
+        response.EnsureSuccessStatusCode();
     }
 
     public void Dispose()

--- a/src/SkillServer/ApiKeyEndpointFilter.cs
+++ b/src/SkillServer/ApiKeyEndpointFilter.cs
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiKeyEndpointFilter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using SkillServer.Models;
+using SkillServer.Services;
+
+namespace SkillServer;
+
+public sealed class ApiKeyEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var apiKeyService = context.HttpContext.RequestServices.GetRequiredService<ApiKeyService>();
+
+        if (!await apiKeyService.IsAuthenticationEnabledAsync(context.HttpContext.RequestAborted))
+            return await next(context);
+
+        var authHeader = context.HttpContext.Request.Headers.Authorization.ToString();
+
+        if (string.IsNullOrEmpty(authHeader))
+        {
+            return Results.Json(
+                new ErrorResponse
+                {
+                    Error = "unauthorized",
+                    Message = "API key required. Provide via 'Authorization: Bearer <key>' header."
+                },
+                SkillServerJsonContext.Default.ErrorResponse,
+                statusCode: 401);
+        }
+
+        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.Json(
+                new ErrorResponse
+                {
+                    Error = "unauthorized",
+                    Message = "Unsupported authorization scheme. Use 'Authorization: Bearer <key>'."
+                },
+                SkillServerJsonContext.Default.ErrorResponse,
+                statusCode: 401);
+        }
+
+        var rawKey = authHeader["Bearer ".Length..].Trim();
+
+        if (string.IsNullOrEmpty(rawKey))
+        {
+            return Results.Json(
+                new ErrorResponse
+                {
+                    Error = "unauthorized",
+                    Message = "API key required. Provide via 'Authorization: Bearer <key>' header."
+                },
+                SkillServerJsonContext.Default.ErrorResponse,
+                statusCode: 401);
+        }
+
+        if (!await apiKeyService.ValidateKeyAsync(rawKey, context.HttpContext.RequestAborted))
+        {
+            return Results.Json(
+                new ErrorResponse
+                {
+                    Error = "forbidden",
+                    Message = "Invalid or expired API key."
+                },
+                SkillServerJsonContext.Default.ErrorResponse,
+                statusCode: 403);
+        }
+
+        return await next(context);
+    }
+}

--- a/src/SkillServer/Data/ApiKeyRepository.cs
+++ b/src/SkillServer/Data/ApiKeyRepository.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiKeyRepository.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Dapper;
+using Microsoft.Data.Sqlite;
+using SkillServer.Models;
+
+namespace SkillServer.Data;
+
+public sealed class ApiKeyRepository
+{
+    private readonly string _connectionString;
+
+    public ApiKeyRepository(DatabaseInitializer initializer)
+    {
+        DapperConfiguration.Initialize();
+        _connectionString = initializer.ConnectionString;
+    }
+
+    public async Task<long> CreateKeyAsync(string label, string keyHash, DateTimeOffset? expiresAt,
+        CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        var now = DateTimeOffset.UtcNow.ToString("O");
+        var expiresAtStr = expiresAt?.ToString("O");
+        return await connection.ExecuteScalarAsync<long>(new CommandDefinition(
+            """
+            INSERT INTO api_keys (label, key_hash, created_at, expires_at)
+            VALUES (@label, @keyHash, @now, @expiresAtStr);
+            SELECT last_insert_rowid();
+            """,
+            new { label, keyHash, now, expiresAtStr },
+            cancellationToken: ct));
+    }
+
+    public async Task<ApiKey?> GetKeyByHashAsync(string keyHash, CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        return await connection.QuerySingleOrDefaultAsync<ApiKey>(new CommandDefinition(
+            """
+            SELECT id AS Id, label AS Label, key_hash AS KeyHash,
+                   created_at AS CreatedAt, expires_at AS ExpiresAt
+            FROM api_keys WHERE key_hash = @keyHash
+            """,
+            new { keyHash },
+            cancellationToken: ct));
+    }
+
+    public async Task<IReadOnlyList<ApiKey>> GetAllKeysAsync(CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        var keys = await connection.QueryAsync<ApiKey>(new CommandDefinition(
+            """
+            SELECT id AS Id, label AS Label, key_hash AS KeyHash,
+                   created_at AS CreatedAt, expires_at AS ExpiresAt
+            FROM api_keys ORDER BY created_at DESC
+            """,
+            cancellationToken: ct));
+        return keys.ToList();
+    }
+
+    public async Task<bool> DeleteKeyIfNotLastAsync(long id, CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        var deleted = await connection.ExecuteAsync(new CommandDefinition(
+            """
+            DELETE FROM api_keys
+            WHERE id = @id AND (SELECT COUNT(*) FROM api_keys) > 1
+            """,
+            new { id },
+            cancellationToken: ct));
+        return deleted > 0;
+    }
+
+    public async Task<bool> AnyKeysExistAsync(CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        var exists = await connection.ExecuteScalarAsync<int>(new CommandDefinition(
+            "SELECT EXISTS(SELECT 1 FROM api_keys LIMIT 1)",
+            cancellationToken: ct));
+        return exists == 1;
+    }
+}

--- a/src/SkillServer/Data/DatabaseInitializer.cs
+++ b/src/SkillServer/Data/DatabaseInitializer.cs
@@ -77,5 +77,16 @@ public sealed class DatabaseInitializer
 
         CREATE INDEX IF NOT EXISTS idx_skill_files_sha256
             ON skill_files(sha256);
+
+        CREATE TABLE IF NOT EXISTS api_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL,
+            key_hash TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL,
+            expires_at TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_api_keys_hash
+            ON api_keys(key_hash);
         """;
 }

--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -17,6 +17,7 @@ public static class Endpoints
         app.MapDiscoveryEndpoints();
         app.MapSkillEndpoints();
         app.MapBlobEndpoints();
+        app.MapApiKeyEndpoints();
         app.MapHealthEndpoints();
         return app;
     }
@@ -41,8 +42,8 @@ public static class Endpoints
         skills.MapGet("/{name}/{version}", GetVersion);
         skills.MapGet("/{name}/{version}/SKILL.md", DownloadSkillMd);
         skills.MapGet("/{name}/{version}/{*path}", DownloadResource);
-        skills.MapPost("/", UploadSkill).DisableAntiforgery();
-        skills.MapDelete("/{name}/{version}", DeleteVersion);
+        skills.MapPost("/", UploadSkill).DisableAntiforgery().AddEndpointFilter<ApiKeyEndpointFilter>();
+        skills.MapDelete("/{name}/{version}", DeleteVersion).AddEndpointFilter<ApiKeyEndpointFilter>();
     }
 
     private static void MapHealthEndpoints(this WebApplication app)
@@ -254,6 +255,77 @@ public static class Endpoints
         var deleted = await repository.DeleteVersionAsync(skill.Id, version, ct);
         if (!deleted)
             return Results.NotFound(new ErrorResponse { Error = "not_found", Message = $"Version '{version}' not found." });
+
+        return Results.NoContent();
+    }
+
+    private static void MapApiKeyEndpoints(this WebApplication app)
+    {
+        var keys = app.MapGroup("/api-keys")
+            .AddEndpointFilter<ApiKeyEndpointFilter>();
+
+        keys.MapPost("/", CreateApiKey);
+        keys.MapGet("/", ListApiKeys);
+        keys.MapDelete("/{id:long}", DeleteApiKey);
+    }
+
+    private static async Task<IResult> CreateApiKey(
+        CreateApiKeyRequest request,
+        ApiKeyService apiKeyService,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.Label))
+        {
+            return Results.BadRequest(new ErrorResponse
+            {
+                Error = "invalid_label",
+                Message = "API key label is required."
+            });
+        }
+
+        var (rawKey, storedKey) = await apiKeyService.CreateKeyAsync(
+            request.Label, request.ExpiresAt, ct);
+
+        return Results.Created($"/api-keys/{storedKey.Id}", new CreateApiKeyResponse
+        {
+            Id = storedKey.Id,
+            Label = storedKey.Label,
+            Key = rawKey,
+            CreatedAt = storedKey.CreatedAt,
+            ExpiresAt = storedKey.ExpiresAt
+        });
+    }
+
+    private static async Task<IResult> ListApiKeys(
+        ApiKeyService apiKeyService,
+        CancellationToken ct)
+    {
+        var keys = await apiKeyService.ListKeysAsync(ct);
+        var summaries = keys.Select(k => new ApiKeySummary
+        {
+            Id = k.Id,
+            Label = k.Label,
+            CreatedAt = k.CreatedAt,
+            ExpiresAt = k.ExpiresAt
+        }).ToList();
+
+        return Results.Json(summaries, SkillServerJsonContext.Default.IReadOnlyListApiKeySummary);
+    }
+
+    private static async Task<IResult> DeleteApiKey(
+        long id,
+        ApiKeyService apiKeyService,
+        CancellationToken ct)
+    {
+        var deleted = await apiKeyService.DeleteKeyAsync(id, ct);
+        if (!deleted)
+        {
+            return Results.BadRequest(new ErrorResponse
+            {
+                Error = "delete_failed",
+                Message = "Cannot delete key. It may not exist or it may be the last remaining key."
+            });
+        }
 
         return Results.NoContent();
     }

--- a/src/SkillServer/Models/ApiKey.cs
+++ b/src/SkillServer/Models/ApiKey.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiKey.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace SkillServer.Models;
+
+public sealed record ApiKey
+{
+    public required long Id { get; init; }
+    public required string Label { get; init; }
+    public required string KeyHash { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? ExpiresAt { get; init; }
+}

--- a/src/SkillServer/Models/ApiModels.cs
+++ b/src/SkillServer/Models/ApiModels.cs
@@ -114,3 +114,45 @@ public sealed record ErrorResponse
     [JsonPropertyName("message")]
     public required string Message { get; init; }
 }
+
+public sealed record CreateApiKeyRequest
+{
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+public sealed record CreateApiKeyResponse
+{
+    [JsonPropertyName("id")]
+    public required long Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("key")]
+    public required string Key { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+public sealed record ApiKeySummary
+{
+    [JsonPropertyName("id")]
+    public required long Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+}

--- a/src/SkillServer/Models/SkillServerJsonContext.cs
+++ b/src/SkillServer/Models/SkillServerJsonContext.cs
@@ -20,6 +20,10 @@ namespace SkillServer.Models;
 [JsonSerializable(typeof(IReadOnlyList<SkillSummary>))]
 [JsonSerializable(typeof(IReadOnlyList<SkillVersionSummary>))]
 [JsonSerializable(typeof(ErrorResponse))]
+[JsonSerializable(typeof(CreateApiKeyRequest))]
+[JsonSerializable(typeof(CreateApiKeyResponse))]
+[JsonSerializable(typeof(ApiKeySummary))]
+[JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/SkillServer/Program.cs
+++ b/src/SkillServer/Program.cs
@@ -23,14 +23,20 @@ builder.Services.AddOpenApi();
 builder.Services.AddSingleton<DatabaseInitializer>();
 builder.Services.AddSingleton<BlobStorage>();
 builder.Services.AddSingleton<SkillRepository>();
+builder.Services.AddSingleton<ApiKeyRepository>();
 builder.Services.AddSingleton<IndexGenerator>();
 builder.Services.AddSingleton<SkillUploadService>();
+builder.Services.AddSingleton<ApiKeyService>();
 
 var app = builder.Build();
 
 // Initialize database
 var dbInitializer = app.Services.GetRequiredService<DatabaseInitializer>();
 await dbInitializer.InitializeAsync();
+
+// Seed API key from environment variable
+var apiKeyService = app.Services.GetRequiredService<ApiKeyService>();
+await apiKeyService.SeedFromEnvironmentAsync();
 
 // Configure pipeline
 if (app.Environment.IsDevelopment())

--- a/src/SkillServer/Services/ApiKeyService.cs
+++ b/src/SkillServer/Services/ApiKeyService.cs
@@ -1,0 +1,120 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiKeyService.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+using SkillServer.Data;
+using SkillServer.Models;
+
+namespace SkillServer.Services;
+
+public sealed class ApiKeyService
+{
+    private readonly ApiKeyRepository _repository;
+    private readonly ILogger<ApiKeyService> _logger;
+    // -1 = unknown, 0 = no keys, 1 = keys exist
+    private volatile int _authEnabled = -1;
+
+    public ApiKeyService(ApiKeyRepository repository, ILogger<ApiKeyService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<(string RawKey, ApiKey StoredKey)> CreateKeyAsync(
+        string label, DateTimeOffset? expiresAt = null, CancellationToken ct = default)
+    {
+        var rawKey = GenerateRawKey();
+        var keyHash = HashKey(rawKey);
+        var now = DateTimeOffset.UtcNow;
+
+        var id = await _repository.CreateKeyAsync(label, keyHash, expiresAt, ct);
+
+        _authEnabled = 1;
+        _logger.LogInformation("Created API key '{Label}' (id={Id})", label, id);
+
+        return (rawKey, new ApiKey
+        {
+            Id = id,
+            Label = label,
+            KeyHash = keyHash,
+            CreatedAt = now,
+            ExpiresAt = expiresAt
+        });
+    }
+
+    public async Task<bool> ValidateKeyAsync(string rawKey, CancellationToken ct = default)
+    {
+        var keyHashHex = HashKey(rawKey);
+        var storedKey = await _repository.GetKeyByHashAsync(keyHashHex, ct);
+
+        if (storedKey is null)
+            return false;
+
+        if (storedKey.ExpiresAt.HasValue && storedKey.ExpiresAt.Value < DateTimeOffset.UtcNow)
+            return false;
+
+        return true;
+    }
+
+    public async Task<bool> IsAuthenticationEnabledAsync(CancellationToken ct = default)
+    {
+        var state = _authEnabled;
+        if (state >= 0)
+            return state == 1;
+
+        var result = await _repository.AnyKeysExistAsync(ct);
+        _authEnabled = result ? 1 : 0;
+        return result;
+    }
+
+    public async Task SeedFromEnvironmentAsync(CancellationToken ct = default)
+    {
+        var envKey = Environment.GetEnvironmentVariable("SKILLSERVER__APIKEY");
+        if (string.IsNullOrWhiteSpace(envKey))
+            return;
+
+        if (await _repository.AnyKeysExistAsync(ct))
+        {
+            _logger.LogDebug("API keys already exist, skipping environment seed");
+            _authEnabled = 1;
+            return;
+        }
+
+        var keyHash = HashKey(envKey);
+        await _repository.CreateKeyAsync("bootstrap", keyHash, expiresAt: null, ct);
+        _authEnabled = 1;
+        _logger.LogInformation("Seeded initial API key from SKILLSERVER__APIKEY environment variable");
+    }
+
+    public async Task<IReadOnlyList<ApiKey>> ListKeysAsync(CancellationToken ct = default)
+    {
+        return await _repository.GetAllKeysAsync(ct);
+    }
+
+    public async Task<bool> DeleteKeyAsync(long id, CancellationToken ct = default)
+    {
+        var deleted = await _repository.DeleteKeyIfNotLastAsync(id, ct);
+        if (deleted)
+        {
+            _authEnabled = -1;
+            _logger.LogInformation("Deleted API key id={Id}", id);
+        }
+
+        return deleted;
+    }
+
+    private static string GenerateRawKey()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return $"sk-{Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')}";
+    }
+
+    internal static string HashKey(string rawKey)
+    {
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
+    }
+}

--- a/src/SkillServer/SkillServer.csproj
+++ b/src/SkillServer/SkillServer.csproj
@@ -24,6 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SkillServer.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Dapper" />
     <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/tests/SkillServer.Integration.Tests/SkillServerFixture.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerFixture.cs
@@ -11,12 +11,18 @@ namespace SkillServer.Integration.Tests;
 
 public sealed class SkillServerFixture : IAsyncLifetime
 {
+    public const string TestApiKey = "sk-test-integration-key-12345";
+
     private WebApplicationFactory<Program>? _factory;
     private HttpClient? _httpClient;
+    private HttpClient? _authHttpClient;
     private SkillServerClient? _client;
 
     public HttpClient HttpClient => _httpClient
         ?? throw new InvalidOperationException("HttpClient not initialized");
+
+    public HttpClient AuthenticatedHttpClient => _authHttpClient
+        ?? throw new InvalidOperationException("Authenticated HttpClient not initialized");
 
     public SkillServerClient Client => _client
         ?? throw new InvalidOperationException("Client not initialized");
@@ -25,6 +31,11 @@ public sealed class SkillServerFixture : IAsyncLifetime
     {
         _factory = new WebApplicationFactory<Program>();
         _httpClient = _factory.CreateClient();
+
+        _authHttpClient = _factory.CreateClient();
+        _authHttpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", TestApiKey);
+
         _client = new SkillServerClient(_httpClient);
 
         return ValueTask.CompletedTask;
@@ -33,6 +44,7 @@ public sealed class SkillServerFixture : IAsyncLifetime
     public async ValueTask DisposeAsync()
     {
         _httpClient?.Dispose();
+        _authHttpClient?.Dispose();
         _client?.Dispose();
 
         if (_factory is not null)

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -5,7 +5,9 @@
 // -----------------------------------------------------------------------
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using Netclaw.SkillClient;
 using Xunit;
 
@@ -74,10 +76,10 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        var uploadResponse = await _fixture.HttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        // List skills - should contain our skill
+        // List skills - should contain our skill (no auth required for reads)
         var skills = await _fixture.Client.ListSkillsAsync(ct: ct);
         Assert.Contains(skills, s => s.Name == skillName);
 
@@ -129,7 +131,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.HttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
 
         // Get the version to find the digest
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
@@ -167,14 +169,14 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.HttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
 
         // Verify it exists
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
         Assert.NotNull(version);
 
-        // Delete it
-        var deleteResponse = await _fixture.HttpClient.DeleteAsync($"/skills/{skillName}/1.0.0", ct);
+        // Delete it (requires auth)
+        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/skills/{skillName}/1.0.0", ct);
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         // Verify it's gone
@@ -209,7 +211,7 @@ public sealed class SkillServerIntegrationTests
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
             content.Add(fileContent, "file", "SKILL.md");
 
-            await _fixture.HttpClient.PostAsync("/skills", content, ct);
+            await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
         }
 
         // Test pagination - get all skills then verify we can paginate
@@ -220,5 +222,102 @@ public sealed class SkillServerIntegrationTests
         // Test take
         var limited = await _fixture.Client.ListSkillsAsync(take: 2, ct: ct);
         Assert.Equal(2, limited.Count);
+    }
+
+    [Fact]
+    public async Task UploadSkill_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent("no-auth-test"), "name");
+        content.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent = new ByteArrayContent("---\nname: no-auth-test\ndescription: test\n---\n# Test"u8.ToArray());
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content.Add(fileContent, "file", "SKILL.md");
+
+        var response = await _fixture.HttpClient.PostAsync("/skills", content, ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteSkill_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _fixture.HttpClient.DeleteAsync("/skills/nonexistent/1.0.0", ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UploadSkill_WithInvalidApiKey_Returns403()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent("bad-key-test"), "name");
+        content.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent = new ByteArrayContent("---\nname: bad-key-test\ndescription: test\n---\n# Test"u8.ToArray());
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content.Add(fileContent, "file", "SKILL.md");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/skills");
+        request.Content = content;
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sk-invalid-key");
+
+        var response = await _fixture.HttpClient.SendAsync(request, ct);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSkills_WithoutApiKey_Returns200()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _fixture.HttpClient.GetAsync("/skills", ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApiKeyManagement_CreateListDelete_EndToEnd()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Create a new key
+        var createResponse = await _fixture.AuthenticatedHttpClient.PostAsJsonAsync("/api-keys",
+            new { label = "test-key" }, ct);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            TypeInfoResolver = SkillServerClientJsonContext.Default
+        };
+        var created = await createResponse.Content.ReadFromJsonAsync<Netclaw.SkillClient.CreateApiKeyResponse>(jsonOptions, ct);
+        Assert.NotNull(created);
+        Assert.Equal("test-key", created.Label);
+        Assert.StartsWith("sk-", created.Key);
+
+        // List keys
+        var listResponse = await _fixture.AuthenticatedHttpClient.GetAsync("/api-keys", ct);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+
+        var keys = await listResponse.Content.ReadFromJsonAsync<IReadOnlyList<Netclaw.SkillClient.ApiKeySummary>>(jsonOptions, ct);
+        Assert.NotNull(keys);
+        Assert.Contains(keys, k => k.Label == "test-key");
+
+        // Delete the new key (not the bootstrap key)
+        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/api-keys/{created.Id}", ct);
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApiKeyManagement_WithoutAuth_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _fixture.HttpClient.GetAsync("/api-keys", ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 }

--- a/tests/SkillServer.Integration.Tests/TestEnvironmentInitializer.cs
+++ b/tests/SkillServer.Integration.Tests/TestEnvironmentInitializer.cs
@@ -13,5 +13,6 @@ internal static class TestEnvironmentInitializer
     internal static void Initialize()
     {
         Environment.SetEnvironmentVariable("DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE", "false");
+        Environment.SetEnvironmentVariable("SKILLSERVER__APIKEY", "sk-test-integration-key-12345");
     }
 }

--- a/tests/SkillServer.Tests/ApiKeyServiceTests.cs
+++ b/tests/SkillServer.Tests/ApiKeyServiceTests.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiKeyServiceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using SkillServer.Services;
+using Xunit;
+
+namespace SkillServer.Tests;
+
+public sealed class ApiKeyHashTests
+{
+    [Fact]
+    public void HashKey_ProducesDeterministicResult()
+    {
+        var hash1 = ApiKeyService.HashKey("test-key-123");
+        var hash2 = ApiKeyService.HashKey("test-key-123");
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashKey_DifferentInputs_ProduceDifferentHashes()
+    {
+        var hash1 = ApiKeyService.HashKey("key-one");
+        var hash2 = ApiKeyService.HashKey("key-two");
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashKey_Returns64CharLowercaseHex()
+    {
+        var hash = ApiKeyService.HashKey("test-key");
+        Assert.Equal(64, hash.Length);
+        Assert.Equal(hash, hash.ToLowerInvariant());
+        Assert.Matches("^[a-f0-9]{64}$", hash);
+    }
+}


### PR DESCRIPTION
## Summary

- Add SHA-256 hashed API key authentication protecting write endpoints (`POST /skills`, `DELETE /skills/{name}/{version}`) while keeping all read/discovery endpoints open
- Add key management API (`POST/GET/DELETE /api-keys`) for creating, listing, and revoking keys
- Bootstrap first key via `SKILLSERVER__APIKEY` environment variable on first run
- Update client library (`Netclaw.SkillClient`) with `apiKey` constructor parameter and write methods (`UploadSkillAsync`, `DeleteVersionAsync`)

### Design decisions
- Keys stored as SHA-256 hashes in SQLite — raw keys shown once at creation, never persisted
- `IEndpointFilter` on write endpoints only — clean Minimal API pattern
- Auth-enabled state cached in memory (invalidated on key mutations) to avoid per-request DB queries
- Atomic SQL for delete-last-key guard — no TOCTOU race
- When no keys exist in DB, auth is disabled (backwards-compatible with v1 behavior)

## Test plan

- [x] `dotnet build -c Release` — zero warnings
- [x] `dotnet test -c Release` — all 61 tests pass (48 unit + 13 integration)
- [x] New integration tests: upload without key returns 401, invalid key returns 403, reads stay open at 200, key management CRUD end-to-end, key management without auth returns 401
- [x] Existing tests updated to use authenticated client for write operations
- [x] Copyright headers verified via `Add-FileHeaders.ps1 -Verify`