### PR TITLE
Add dedicated client library README and link to Cloudflare spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A self-hosted skill server for managing AI agent skills internally within organi
 
 SkillServer implements two complementary standards:
 
-- **AgentSkills.io** - The SKILL.md format standard (originally by Anthropic)
-- **Cloudflare Agent Skills Discovery RFC v0.2.0** - Discovery via `/.well-known/agent-skills/index.json`
+- **[AgentSkills.io](https://agentskills.io)** - The SKILL.md format standard (originally by Anthropic)
+- **[Cloudflare Agent Skills Discovery RFC v0.2.0](https://github.com/cloudflare/agent-skills-spec)** - Discovery via `/.well-known/agent-skills/index.json`
 - **NetClaw manifest.json** - Backwards compatibility with existing NetClaw infrastructure
 
 ## Quick Start
@@ -100,39 +100,22 @@ curl -X POST http://localhost:8080/skills \
 
 ## Client Library
 
-Install the client library:
+The `Netclaw.SkillClient` NuGet package provides a typed .NET client for SkillServer.
 
 ```bash
 dotnet add package Netclaw.SkillClient
 ```
 
-Usage:
-
 ```csharp
 using Netclaw.SkillClient;
 
-// Direct instantiation (read-only, no auth needed)
-using var client = new SkillServerClient("http://localhost:8080");
+using var client = new SkillServerClient("http://localhost:8080", apiKey: "sk-your-api-key");
 
-// With API key for write operations
-using var authClient = new SkillServerClient("http://localhost:8080", apiKey: "sk-your-api-key");
-
-// Or via DI
-services.AddSkillServerClient("http://localhost:8080");
-services.AddSkillServerClient("http://localhost:8080", "sk-your-api-key");
-
-// Get RFC index
 var index = await client.GetRfcIndexAsync();
-
-// Get NetClaw manifest
-var manifest = await client.GetNetclawManifestAsync();
-
-// Download a skill
 var content = await client.GetSkillFileAsStringAsync("my-skill", "1.0.0");
-
-// Verify digest
-var isValid = await client.VerifyDigestAsync("my-skill", "1.0.0", "sha256:...");
 ```
+
+See the [client library README](src/Netclaw.SkillClient/README.md) for full API documentation.
 
 ## NetClaw Integration
 

--- a/src/Netclaw.SkillClient/Netclaw.SkillClient.csproj
+++ b/src/Netclaw.SkillClient/Netclaw.SkillClient.csproj
@@ -15,6 +15,12 @@
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
+  <!-- Override Directory.Build.props README with client-specific one -->
+  <ItemGroup>
+    <None Remove="$(MSBuildThisFileDirectory)..\..\README.md" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>

--- a/src/Netclaw.SkillClient/README.md
+++ b/src/Netclaw.SkillClient/README.md
@@ -1,0 +1,112 @@
+# Netclaw.SkillClient
+
+.NET client library for [SkillServer](https://github.com/netclaw-dev/skill-server), a self-hosted skill registry for AI agents.
+
+SkillServer implements the [Cloudflare Agent Skills Discovery RFC v0.2.0](https://github.com/cloudflare/agent-skills-spec) and the [AgentSkills.io](https://agentskills.io) SKILL.md format.
+
+## Installation
+
+```bash
+dotnet add package Netclaw.SkillClient
+```
+
+## Usage
+
+### Direct Instantiation
+
+```csharp
+using Netclaw.SkillClient;
+
+// Read-only access (no auth needed for discovery and downloads)
+using var client = new SkillServerClient("http://localhost:8080");
+
+// With API key for write operations (publish, delete)
+using var client = new SkillServerClient("http://localhost:8080", apiKey: "sk-your-api-key");
+```
+
+### Dependency Injection
+
+```csharp
+// Read-only
+services.AddSkillServerClient("http://localhost:8080");
+
+// With API key
+services.AddSkillServerClient("http://localhost:8080", "sk-your-api-key");
+```
+
+## Discovering Skills
+
+```csharp
+// Get the RFC-compliant skill index (/.well-known/agent-skills/index.json)
+var index = await client.GetRfcIndexAsync();
+
+foreach (var skill in index.Skills)
+{
+    Console.WriteLine($"{skill.Name} - {skill.Description}");
+    Console.WriteLine($"  URL: {skill.Url}");
+    Console.WriteLine($"  Digest: {skill.Digest}");
+}
+```
+
+## Listing and Browsing Skills
+
+```csharp
+// List all skills (paginated)
+var skills = await client.ListSkillsAsync();
+var page = await client.ListSkillsAsync(skip: 10, take: 5);
+
+// Get all versions of a skill
+var versions = await client.GetSkillVersionsAsync("my-skill");
+
+// Get a specific version
+var version = await client.GetVersionAsync("my-skill", "1.0.0");
+```
+
+## Downloading Skills
+
+```csharp
+// Download SKILL.md as a string
+var content = await client.GetSkillFileAsStringAsync("my-skill", "1.0.0");
+
+// Download SKILL.md as a stream
+await using var stream = await client.GetSkillFileAsync("my-skill", "1.0.0");
+
+// Download a resource file from a skill archive
+await using var resource = await client.GetSkillFileAsync("my-skill", "1.0.0", "prompts/system.md");
+
+// Download a blob by its SHA-256 digest
+await using var blob = await client.GetBlobAsync("sha256:abc123...");
+```
+
+## Verifying Integrity
+
+```csharp
+// Verify a downloaded skill matches its published digest
+var isValid = await client.VerifyDigestAsync("my-skill", "1.0.0", "sha256:abc123...");
+```
+
+## Publishing Skills
+
+Requires an API key with write access.
+
+```csharp
+await using var file = File.OpenRead("SKILL.md");
+var result = await client.UploadSkillAsync("my-skill", "1.0.0", file, category: "coding");
+
+Console.WriteLine($"Published: {result.Url}");
+Console.WriteLine($"Digest: {result.Sha256}");
+```
+
+## Deleting Skills
+
+```csharp
+await client.DeleteVersionAsync("my-skill", "1.0.0");
+```
+
+## AOT Compatibility
+
+This library is fully AOT-compatible. All JSON serialization uses source-generated `System.Text.Json` contexts with no runtime reflection.
+
+## License
+
+Apache-2.0 - Copyright 2025 [Petabridge, LLC](https://petabridge.com)


### PR DESCRIPTION
## Summary

- Add a dedicated `README.md` for `Netclaw.SkillClient` that ships with the NuGet package, focused on client API usage without server deployment details
- Link to the [Cloudflare Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-spec) and [AgentSkills.io](https://agentskills.io) in the server README
- Remove non-existent `GetNetclawManifestAsync` reference from server README examples
- Trim server README client section to a quick example with link to full client docs

## Test plan

- [x] `dotnet build -c Release` passes with zero warnings
- [x] All 61 tests pass (48 unit + 13 integration)
- [x] NuGet package contains the client README (verified via `unzip -p`)
- [x] Package README starts with `# Netclaw.SkillClient`, not server content