### PR TITLE
Add FTS5 skill search, latest version, and batch update checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ Configuration is via environment variables or `appsettings.json`:
 | Endpoint | Description |
 |----------|-------------|
 | `GET /skills` | List all skills |
+| `GET /skills?q={query}` | Search skills (full-text) |
 | `GET /skills/{name}` | Get skill info (all versions) |
+| `GET /skills/{name}/latest` | Get latest version |
 | `GET /skills/{name}/{version}` | Get specific version metadata |
 | `GET /skills/{name}/{version}/SKILL.md` | Download SKILL.md |
 | `GET /skills/{name}/{version}/{path}` | Download resource file |
+| `POST /skills/check-updates` | Batch update check |
 | `POST /skills` | Upload new skill version (multipart/form-data) 🔑 |
 | `DELETE /skills/{name}/{version}` | Delete version 🔑 |
 
@@ -111,8 +114,16 @@ using Netclaw.SkillClient;
 
 using var client = new SkillServerClient("http://localhost:8080", apiKey: "sk-your-api-key");
 
-var index = await client.GetRfcIndexAsync();
-var content = await client.GetSkillFileAsStringAsync("my-skill", "1.0.0");
+// Full-text search
+var results = await client.SearchSkillsAsync("kubernetes deployment");
+
+// Get latest version of a skill
+var latest = await client.GetLatestVersionAsync("my-skill");
+
+// Batch update check
+var updates = await client.CheckUpdatesAsync([
+    new CheckUpdateRequest { Name = "my-skill", Version = "1.0.0" }
+]);
 ```
 
 See the [client library README](src/Netclaw.SkillClient/README.md) for full API documentation.

--- a/src/Netclaw.SkillClient/Models.cs
+++ b/src/Netclaw.SkillClient/Models.cs
@@ -121,6 +121,36 @@ public sealed record SkillVersionSummary
     public int FileCount { get; init; }
 }
 
+public sealed record CheckUpdateRequest
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = "";
+}
+
+public sealed record CheckUpdateResponse
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    [JsonPropertyName("currentVersion")]
+    public string CurrentVersion { get; init; } = "";
+
+    [JsonPropertyName("latestVersion")]
+    public string LatestVersion { get; init; } = "";
+
+    [JsonPropertyName("latestDigest")]
+    public string LatestDigest { get; init; } = "";
+
+    [JsonPropertyName("latestPublishedAt")]
+    public DateTimeOffset LatestPublishedAt { get; init; }
+
+    [JsonPropertyName("hasUpdate")]
+    public bool HasUpdate { get; init; }
+}
+
 public sealed record SkillUploadResponse
 {
     [JsonPropertyName("name")]
@@ -180,5 +210,7 @@ public sealed record ApiKeySummary
 [JsonSerializable(typeof(CreateApiKeyResponse))]
 [JsonSerializable(typeof(ApiKeySummary))]
 [JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
+[JsonSerializable(typeof(IReadOnlyList<CheckUpdateRequest>))]
+[JsonSerializable(typeof(IReadOnlyList<CheckUpdateResponse>))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 public partial class SkillServerClientJsonContext : JsonSerializerContext;

--- a/src/Netclaw.SkillClient/README.md
+++ b/src/Netclaw.SkillClient/README.md
@@ -62,6 +62,37 @@ var versions = await client.GetSkillVersionsAsync("my-skill");
 var version = await client.GetVersionAsync("my-skill", "1.0.0");
 ```
 
+## Searching Skills
+
+```csharp
+// Full-text search across skill names, descriptions, and categories
+var results = await client.SearchSkillsAsync("kubernetes deployment");
+var page = await client.SearchSkillsAsync("kubernetes", skip: 0, take: 10);
+```
+
+## Getting the Latest Version
+
+```csharp
+// Get the latest version of a specific skill
+var latest = await client.GetLatestVersionAsync("my-skill");
+Console.WriteLine($"Latest: {latest.Version} ({latest.Sha256})");
+```
+
+## Checking for Updates
+
+```csharp
+// Check if any of your cached skills have newer versions
+var updates = await client.CheckUpdatesAsync([
+    new CheckUpdateRequest { Name = "my-skill", Version = "1.0.0" },
+    new CheckUpdateRequest { Name = "other-skill", Version = "2.1.0" }
+]);
+
+foreach (var item in updates.Where(u => u.HasUpdate))
+{
+    Console.WriteLine($"{item.Name}: {item.CurrentVersion} -> {item.LatestVersion}");
+}
+```
+
 ## Downloading Skills
 
 ```csharp

--- a/src/Netclaw.SkillClient/SkillServerClient.cs
+++ b/src/Netclaw.SkillClient/SkillServerClient.cs
@@ -151,6 +151,46 @@ public sealed class SkillServerClient : IDisposable
         return actualHex == expectedHex;
     }
 
+    /// <summary>
+    /// Searches skills using full-text search.
+    /// </summary>
+    public async Task<IReadOnlyList<SkillSummary>> SearchSkillsAsync(
+        string query, int? skip = null, int? take = null, CancellationToken ct = default)
+    {
+        var queryParams = new List<string> { $"q={Uri.EscapeDataString(query)}" };
+        if (skip.HasValue) queryParams.Add($"skip={skip.Value}");
+        if (take.HasValue) queryParams.Add($"take={take.Value}");
+
+        var url = $"skills?{string.Join("&", queryParams)}";
+        var result = await _httpClient.GetFromJsonAsync(url,
+            SkillServerClientJsonContext.Default.IReadOnlyListSkillSummary, ct);
+        return result ?? [];
+    }
+
+    /// <summary>
+    /// Gets the latest version of a skill by name.
+    /// </summary>
+    public async Task<SkillVersionSummary?> GetLatestVersionAsync(string name, CancellationToken ct = default)
+    {
+        return await _httpClient.GetFromJsonAsync(
+            $"skills/{Uri.EscapeDataString(name)}/latest",
+            SkillServerClientJsonContext.Default.SkillVersionSummary, ct);
+    }
+
+    /// <summary>
+    /// Checks if any of the specified skills have newer versions available.
+    /// </summary>
+    public async Task<IReadOnlyList<CheckUpdateResponse>> CheckUpdatesAsync(
+        IReadOnlyList<CheckUpdateRequest> items, CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("skills/check-updates", items,
+            SkillServerClientJsonContext.Default.IReadOnlyListCheckUpdateRequest, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync(
+            SkillServerClientJsonContext.Default.IReadOnlyListCheckUpdateResponse, ct);
+        return result ?? [];
+    }
+
     public async Task<SkillUploadResponse> UploadSkillAsync(
         string name, string version, Stream skillMdContent, string? category = null,
         CancellationToken ct = default)

--- a/src/SkillServer/Data/DatabaseInitializer.cs
+++ b/src/SkillServer/Data/DatabaseInitializer.cs
@@ -35,6 +35,15 @@ public sealed class DatabaseInitializer
 
         await connection.ExecuteAsync(Schema);
 
+        // Populate FTS from existing data (migration step for existing databases)
+        await connection.ExecuteAsync("""
+            INSERT INTO skills_fts(rowid, name, description, category)
+            SELECT s.id, s.name, sv.description, COALESCE(sv.category, '')
+            FROM skills s
+            JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_latest = 1
+            WHERE s.id NOT IN (SELECT rowid FROM skills_fts);
+            """);
+
         _logger.LogInformation("Database schema initialized");
     }
 
@@ -88,5 +97,35 @@ public sealed class DatabaseInitializer
 
         CREATE INDEX IF NOT EXISTS idx_api_keys_hash
             ON api_keys(key_hash);
+
+        -- Full-text search index for skill discovery
+        CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
+            name,
+            description,
+            category
+        );
+
+        -- Keep FTS in sync when new versions are published
+        CREATE TRIGGER IF NOT EXISTS trg_skills_fts_insert
+        AFTER INSERT ON skill_versions
+        WHEN NEW.is_latest = 1
+        BEGIN
+            DELETE FROM skills_fts WHERE rowid = NEW.skill_id;
+            INSERT INTO skills_fts(rowid, name, description, category)
+            SELECT NEW.skill_id, s.name, NEW.description, COALESCE(NEW.category, '')
+            FROM skills s WHERE s.id = NEW.skill_id;
+        END;
+
+        -- Keep FTS in sync when versions are deleted
+        CREATE TRIGGER IF NOT EXISTS trg_skills_fts_delete
+        AFTER DELETE ON skill_versions
+        BEGIN
+            DELETE FROM skills_fts WHERE rowid = OLD.skill_id;
+            INSERT INTO skills_fts(rowid, name, description, category)
+            SELECT s.id, s.name, sv.description, COALESCE(sv.category, '')
+            FROM skills s
+            JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_latest = 1
+            WHERE s.id = OLD.skill_id;
+        END;
         """;
 }

--- a/src/SkillServer/Data/SkillRepository.cs
+++ b/src/SkillServer/Data/SkillRepository.cs
@@ -258,6 +258,89 @@ public sealed class SkillRepository
             new { versionId, relativePath, sha256, sizeBytes });
     }
 
+    public async Task<IReadOnlyList<SkillVersionWithMetadata>> SearchSkillsAsync(
+        string query, int? skip = null, int? take = null, CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+
+        // Sanitize and prepare FTS5 query: split on non-alphanumeric chars, append * for prefix matching
+        var terms = query.Split(FtsTokenSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (terms.Length == 0)
+            return [];
+
+        var ftsQuery = string.Join(" ", terms.Select(t => EscapeFtsToken(t)).Where(t => t.Length > 0).Select(t => t + "*"));
+        if (string.IsNullOrEmpty(ftsQuery))
+            return [];
+
+        var sql = """
+            SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
+                   sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
+                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   s.name AS SkillName, s.created_at AS SkillCreatedAt, s.updated_at AS SkillUpdatedAt,
+                   (SELECT COUNT(*) FROM skill_versions sv2 WHERE sv2.skill_id = s.id) AS VersionCount
+            FROM skills_fts
+            JOIN skills s ON s.id = skills_fts.rowid
+            JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_latest = 1
+            WHERE skills_fts MATCH @ftsQuery
+            ORDER BY rank
+            """;
+
+        if (take.HasValue)
+            sql += $" LIMIT {take.Value}";
+        if (skip.HasValue)
+            sql += $" OFFSET {skip.Value}";
+
+        var versions = await connection.QueryAsync<SkillVersionWithMetadata>(sql, new { ftsQuery });
+        return versions.ToList();
+    }
+
+    private static readonly char[] FtsTokenSeparators = [' ', '-', '_', '.', ',', '/', '\\', ':', ';'];
+
+    private static string EscapeFtsToken(string token)
+    {
+        // Keep only alphanumeric characters to prevent FTS5 query syntax injection
+        return new string(token.Where(char.IsLetterOrDigit).ToArray());
+    }
+
+    public async Task<SkillVersionWithFileCount?> GetLatestVersionByNameAsync(string name, CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        return await connection.QuerySingleOrDefaultAsync<SkillVersionWithFileCount>(
+            """
+            SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
+                   sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
+                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   (SELECT COUNT(*) FROM skill_files sf WHERE sf.skill_version_id = sv.id) AS FileCount
+            FROM skill_versions sv
+            JOIN skills s ON s.id = sv.skill_id
+            WHERE s.name = @name COLLATE NOCASE AND sv.is_latest = 1
+            """,
+            new { name });
+    }
+
+    public async Task<IReadOnlyList<SkillUpdateInfo>> CheckUpdatesAsync(
+        IReadOnlyList<(string Name, string Version)> skills, CancellationToken ct = default)
+    {
+        if (skills.Count == 0)
+            return [];
+
+        await using var connection = new SqliteConnection(_connectionString);
+
+        // Query all requested skills in one shot
+        var names = skills.Select(s => s.Name).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var results = await connection.QueryAsync<SkillUpdateInfo>(
+            """
+            SELECT s.name AS Name, sv.version AS LatestVersion, sv.sha256 AS LatestDigest,
+                   sv.published_at AS LatestPublishedAt
+            FROM skills s
+            JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_latest = 1
+            WHERE s.name IN @names COLLATE NOCASE
+            """,
+            new { names });
+
+        return results.ToList();
+    }
+
     public async Task<bool> DeleteVersionAsync(long skillId, string version, CancellationToken ct = default)
     {
         await using var connection = new SqliteConnection(_connectionString);

--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -39,9 +39,11 @@ public static class Endpoints
 
         skills.MapGet("/", ListSkills);
         skills.MapGet("/{name}", GetSkill);
+        skills.MapGet("/{name}/latest", GetLatestVersion);
         skills.MapGet("/{name}/{version}", GetVersion);
         skills.MapGet("/{name}/{version}/SKILL.md", DownloadSkillMd);
         skills.MapGet("/{name}/{version}/{*path}", DownloadResource);
+        skills.MapPost("/check-updates", CheckUpdates);
         skills.MapPost("/", UploadSkill).DisableAntiforgery().AddEndpointFilter<ApiKeyEndpointFilter>();
         skills.MapDelete("/{name}/{version}", DeleteVersion).AddEndpointFilter<ApiKeyEndpointFilter>();
     }
@@ -53,11 +55,17 @@ public static class Endpoints
 
     private static async Task<IResult> ListSkills(
         SkillRepository repository,
+        string? q,
         int? skip,
         int? take,
         CancellationToken ct)
     {
-        var latestVersions = await repository.GetAllLatestVersionsWithMetadataAsync(skip, take, ct);
+        IReadOnlyList<SkillVersionWithMetadata> latestVersions;
+
+        if (!string.IsNullOrWhiteSpace(q))
+            latestVersions = await repository.SearchSkillsAsync(q, skip, take, ct);
+        else
+            latestVersions = await repository.GetAllLatestVersionsWithMetadataAsync(skip, take, ct);
 
         var summaries = latestVersions.Select(v => new SkillSummary
         {
@@ -257,6 +265,78 @@ public static class Endpoints
             return Results.NotFound(new ErrorResponse { Error = "not_found", Message = $"Version '{version}' not found." });
 
         return Results.NoContent();
+    }
+
+    private static async Task<IResult> GetLatestVersion(
+        string name,
+        SkillRepository repository,
+        CancellationToken ct)
+    {
+        var latest = await repository.GetLatestVersionByNameAsync(name, ct);
+        if (latest is null)
+            return Results.NotFound(new ErrorResponse { Error = "not_found", Message = $"Skill '{name}' not found." });
+
+        var summary = new SkillVersionSummary
+        {
+            Name = name,
+            Version = latest.Version,
+            Description = latest.Description,
+            Category = latest.Category,
+            Sha256 = latest.Sha256,
+            SizeBytes = latest.SizeBytes,
+            PublishedAt = latest.PublishedAt,
+            IsLatest = latest.IsLatest,
+            FileCount = latest.FileCount
+        };
+
+        return Results.Json(summary, SkillServerJsonContext.Default.SkillVersionSummary);
+    }
+
+    private static async Task<IResult> CheckUpdates(
+        IReadOnlyList<CheckUpdateRequestItem> request,
+        SkillRepository repository,
+        CancellationToken ct)
+    {
+        if (request.Count == 0)
+            return Results.Json(Array.Empty<CheckUpdateResponseItem>(),
+                SkillServerJsonContext.Default.IReadOnlyListCheckUpdateResponseItem);
+
+        if (request.Count > 100)
+            return Results.BadRequest(new ErrorResponse
+                { Error = "too_many_items", Message = "Maximum 100 items per request." });
+
+        var latestVersions = await repository.CheckUpdatesAsync(
+            request.Select(r => (r.Name, r.Version)).ToList(), ct);
+
+        var lookup = latestVersions.ToDictionary(v => v.Name, v => v, StringComparer.OrdinalIgnoreCase);
+
+        var results = request.Select(r =>
+        {
+            if (!lookup.TryGetValue(r.Name, out var latest))
+            {
+                return new CheckUpdateResponseItem
+                {
+                    Name = r.Name,
+                    CurrentVersion = r.Version,
+                    LatestVersion = r.Version,
+                    LatestDigest = "",
+                    LatestPublishedAt = DateTimeOffset.MinValue,
+                    HasUpdate = false
+                };
+            }
+
+            return new CheckUpdateResponseItem
+            {
+                Name = r.Name,
+                CurrentVersion = r.Version,
+                LatestVersion = latest.LatestVersion,
+                LatestDigest = latest.LatestDigest,
+                LatestPublishedAt = latest.LatestPublishedAt,
+                HasUpdate = !string.Equals(r.Version, latest.LatestVersion, StringComparison.OrdinalIgnoreCase)
+            };
+        }).ToList();
+
+        return Results.Json(results, SkillServerJsonContext.Default.IReadOnlyListCheckUpdateResponseItem);
     }
 
     private static void MapApiKeyEndpoints(this WebApplication app)

--- a/src/SkillServer/Models/ApiModels.cs
+++ b/src/SkillServer/Models/ApiModels.cs
@@ -115,6 +115,36 @@ public sealed record ErrorResponse
     public required string Message { get; init; }
 }
 
+public sealed record CheckUpdateRequestItem
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+}
+
+public sealed record CheckUpdateResponseItem
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("currentVersion")]
+    public required string CurrentVersion { get; init; }
+
+    [JsonPropertyName("latestVersion")]
+    public required string LatestVersion { get; init; }
+
+    [JsonPropertyName("latestDigest")]
+    public required string LatestDigest { get; init; }
+
+    [JsonPropertyName("latestPublishedAt")]
+    public required DateTimeOffset LatestPublishedAt { get; init; }
+
+    [JsonPropertyName("hasUpdate")]
+    public required bool HasUpdate { get; init; }
+}
+
 public sealed record CreateApiKeyRequest
 {
     [JsonPropertyName("label")]

--- a/src/SkillServer/Models/Skill.cs
+++ b/src/SkillServer/Models/Skill.cs
@@ -85,6 +85,17 @@ public sealed record SkillVersionWithMetadata
 }
 
 /// <summary>
+/// Update information for a skill returned by batch update checks.
+/// </summary>
+public sealed record SkillUpdateInfo
+{
+    public required string Name { get; init; }
+    public required string LatestVersion { get; init; }
+    public required string LatestDigest { get; init; }
+    public required DateTimeOffset LatestPublishedAt { get; init; }
+}
+
+/// <summary>
 /// Skill type constants.
 /// </summary>
 public static class SkillTypes

--- a/src/SkillServer/Models/SkillServerJsonContext.cs
+++ b/src/SkillServer/Models/SkillServerJsonContext.cs
@@ -24,6 +24,8 @@ namespace SkillServer.Models;
 [JsonSerializable(typeof(CreateApiKeyResponse))]
 [JsonSerializable(typeof(ApiKeySummary))]
 [JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
+[JsonSerializable(typeof(IReadOnlyList<CheckUpdateRequestItem>))]
+[JsonSerializable(typeof(IReadOnlyList<CheckUpdateResponseItem>))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -313,6 +313,162 @@ public sealed class SkillServerIntegrationTests
     }
 
     [Fact]
+    public async Task SearchSkills_ReturnsMatchingResults()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var prefix = $"srch-{Guid.NewGuid():N}"[..10];
+        var skillName = $"{prefix}-finder";
+
+        // Upload a skill with a distinctive description
+        var skillContent = $"""
+            ---
+            name: {skillName}
+            description: Helps with kubernetes pod deployment orchestration
+            ---
+
+            # Search Test
+            """;
+
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent(skillName), "name");
+        content.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content.Add(fileContent, "file", "SKILL.md");
+
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+
+        // Search by description keyword
+        var results = await _fixture.Client.SearchSkillsAsync("kubernetes", ct: ct);
+        Assert.Contains(results, s => s.Name == skillName);
+
+        // Search by name
+        results = await _fixture.Client.SearchSkillsAsync(prefix, ct: ct);
+        Assert.Contains(results, s => s.Name == skillName);
+
+        // Search for non-existent term
+        results = await _fixture.Client.SearchSkillsAsync("zzz-nonexistent-zzz", ct: ct);
+        Assert.DoesNotContain(results, s => s.Name == skillName);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_ReturnsLatest()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"latest-{Guid.NewGuid():N}"[..20];
+
+        // Upload v1.0.0
+        var skillContent1 = $"""
+            ---
+            name: {skillName}
+            description: Version one
+            ---
+
+            # V1
+            """;
+
+        using var content1 = new MultipartFormDataContent();
+        content1.Add(new StringContent(skillName), "name");
+        content1.Add(new StringContent("1.0.0"), "version");
+        var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent1));
+        fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content1.Add(fileContent1, "file", "SKILL.md");
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+
+        // Upload v2.0.0
+        var skillContent2 = $"""
+            ---
+            name: {skillName}
+            description: Version two
+            ---
+
+            # V2
+            """;
+
+        using var content2 = new MultipartFormDataContent();
+        content2.Add(new StringContent(skillName), "name");
+        content2.Add(new StringContent("2.0.0"), "version");
+        var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent2));
+        fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content2.Add(fileContent2, "file", "SKILL.md");
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+
+        // Get latest - should be v2.0.0
+        var latest = await _fixture.Client.GetLatestVersionAsync(skillName, ct);
+        Assert.NotNull(latest);
+        Assert.Equal("2.0.0", latest.Version);
+        Assert.True(latest.IsLatest);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_NotFound_Returns404()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _fixture.HttpClient.GetAsync("/skills/nonexistent-skill/latest", ct);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckUpdates_ReturnsUpdateStatus()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"upd-{Guid.NewGuid():N}"[..20];
+
+        // Upload v1.0.0
+        var skillContent1 = $"""
+            ---
+            name: {skillName}
+            description: Update check test
+            ---
+
+            # V1
+            """;
+
+        using var content1 = new MultipartFormDataContent();
+        content1.Add(new StringContent(skillName), "name");
+        content1.Add(new StringContent("1.0.0"), "version");
+        var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent1));
+        fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content1.Add(fileContent1, "file", "SKILL.md");
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+
+        // Upload v2.0.0
+        var skillContent2 = $"""
+            ---
+            name: {skillName}
+            description: Update check test v2
+            ---
+
+            # V2
+            """;
+
+        using var content2 = new MultipartFormDataContent();
+        content2.Add(new StringContent(skillName), "name");
+        content2.Add(new StringContent("2.0.0"), "version");
+        var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent2));
+        fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content2.Add(fileContent2, "file", "SKILL.md");
+        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+
+        // Check updates - asking about v1.0.0 should show update available
+        var updates = await _fixture.Client.CheckUpdatesAsync([
+            new Netclaw.SkillClient.CheckUpdateRequest { Name = skillName, Version = "1.0.0" },
+            new Netclaw.SkillClient.CheckUpdateRequest { Name = "nonexistent-skill", Version = "1.0.0" }
+        ], ct);
+
+        Assert.Equal(2, updates.Count);
+
+        var skillUpdate = updates.First(u => u.Name == skillName);
+        Assert.True(skillUpdate.HasUpdate);
+        Assert.Equal("1.0.0", skillUpdate.CurrentVersion);
+        Assert.Equal("2.0.0", skillUpdate.LatestVersion);
+
+        var missingSkill = updates.First(u => u.Name == "nonexistent-skill");
+        Assert.False(missingSkill.HasUpdate);
+    }
+
+    [Fact]
     public async Task ApiKeyManagement_WithoutAuth_Returns401()
     {
         var ct = TestContext.Current.CancellationToken;


### PR DESCRIPTION
## Summary

- **FTS5 full-text search**: `GET /skills?q=term` searches across skill names, descriptions, and categories with BM25 ranking and prefix matching. FTS index is kept in sync via SQLite triggers on insert/delete.
- **Latest version endpoint**: `GET /skills/{name}/latest` returns the latest version metadata for a skill without needing to know the version string.
- **Batch update checking**: `POST /skills/check-updates` accepts a list of `{name, version}` pairs and returns which skills have newer versions available. Capped at 100 items per request.
- Client library methods: `SearchSkillsAsync`, `GetLatestVersionAsync`, `CheckUpdatesAsync`
- Both server and client READMEs updated with new capabilities

## Test plan

- [x] `dotnet build -c Release` — zero warnings
- [x] All 65 tests pass (48 unit + 17 integration)
- [x] New integration tests: `SearchSkills_ReturnsMatchingResults`, `GetLatestVersion_ReturnsLatest`, `GetLatestVersion_NotFound_Returns404`, `CheckUpdates_ReturnsUpdateStatus`
- [x] FTS5 search tested: by description keyword, by name prefix, negative match
- [x] Update check tested: skill with update, missing skill (no false positive)