### PR TITLE
chore: add Slopwatch enforcement to CI and agent constitution

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "docfx"
       ],
       "rollForward": false
+    },
+    "slopwatch.cmd": {
+      "version": "0.4.0",
+      "commands": [
+        "slopwatch"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -75,6 +75,29 @@ jobs:
           path: ./bin/nuget/*.nupkg
           retention-days: 7
 
+  slopwatch:
+    name: Slopwatch
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 10
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: "Install .NET SDK"
+        uses: actions/setup-dotnet@v5.1.0
+        with:
+          global-json-file: "./global.json"
+
+      - name: "Restore .NET tools"
+        run: dotnet tool restore
+
+      - name: "slopwatch analyze"
+        run: dotnet slopwatch analyze
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "createdAt": "2026-04-23T01:15:57.3247724+00:00",
+  "updatedAt": "2026-04-23T01:15:57.3298555+00:00",
+  "description": "Initial baseline created by 'slopwatch init' on 2026-04-23 01:15:57 UTC",
+  "entries": [
+    {
+      "hash": "9d4a53dc5193e639",
+      "ruleId": "SW005",
+      "filePath": "Directory.Build.props",
+      "lineNumber": 20,
+      "codeSnippet": "<NoWarn>$(NoWarn);CS1591</NoWarn>",
+      "message": "Adding warnings to NoWarn: CS1591",
+      "baselinedAt": "2026-04-23T01:15:57.32982+00:00"
+    }
+  ]
+}

--- a/.slopwatch/config.json.example
+++ b/.slopwatch/config.json.example
@@ -1,0 +1,10 @@
+{
+  "suppressions": [
+    {
+      "ruleId": "SW002",
+      "pattern": "**/Generated/**",
+      "justification": "Generated code from protobuf/gRPC compiler - cannot be modified"
+    }
+  ],
+  "globalSuppressions": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Read `docs/TOOLING.md` for:
 - **Sealed by default:** Seal classes unless designed for inheritance
 - **Copyright headers:** All `.cs` files require Petabridge headers (run `scripts/Add-FileHeaders.ps1`)
 - **No comments explaining what:** Code should be self-documenting; comment only non-obvious *why*
+- **No Slopwatch violations:** `dotnet slopwatch analyze` must pass — no new violations (see baseline at `.slopwatch/baseline.json`)
 
 ### Testing Requirements
 - Unit tests for business logic and value objects
@@ -43,9 +44,12 @@ Read `docs/TOOLING.md` for:
 - All tests must pass on both ubuntu and windows
 
 ### PR Requirements
-- All CI jobs must pass (Test, NuGet Pack, Docker Build)
+- All CI jobs must pass (Test, NuGet Pack, Slopwatch, Docker Build)
 - Commits should not mention AI agents or assistants
 - Follow existing commit message style (imperative mood, concise)
+- **No new Slopwatch violations:** run `dotnet slopwatch analyze` after code changes
+  - `.slopwatch/baseline.json` — existing entries are accepted, new violations fail CI
+  - Use `dotnet-skills:slopwatch` (if available) after substantial new/refactor/LLM-authored code
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

Add **dotnet-slopwatch** enforcement to the SkillServer project to detect reward hacking in code changes.

## Changes

- **`.config/dotnet-tools.json`** — added `slopwatch.cmd` v0.4.0 tool
- **`.github/workflows/pr_validation.yml`** — new `slopwatch` CI job (runs after test, 10min timeout)
- **`CLAUDE.md`** — added Slopwatch guidance to Code Standards and PR Requirements
- **`AGENTS.md`** — added Slopwatch guidance
- **`.slopwatch/baseline.json`** — initial baseline (1 pre-existing SW005 issue)
- **`.slopwatch/config.json.example`** — config reference

## Verification

- `dotnet slopwatch analyze` returns 0 new issues on current codebase
- Baseline captures 1 existing SW005 violation to prevent false positives