### PR TITLE
SHA-pin all GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
           fetch-depth: 0
 
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           global-json-file: "./global.json"
 
@@ -55,13 +55,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
           fetch-depth: 0
 
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           global-json-file: "./global.json"
 
@@ -69,7 +69,7 @@ jobs:
         run: dotnet pack -c Release -o ./bin/nuget
 
       - name: "Upload NuGet Artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: nuget-packages
           path: ./bin/nuget/*.nupkg
@@ -83,12 +83,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           global-json-file: "./global.json"
 
@@ -105,13 +105,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
           fetch-depth: 0
 
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           global-json-file: "./global.json"
 

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -27,18 +27,18 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         lfs: true
         fetch-depth: 0
 
     - name: "Install .NET SDK"
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         global-json-file: "./global.json"
 
     - name: "Login to GitHub Container Registry"
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: "Login to GitHub Container Registry"
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         lfs: true
         fetch-depth: 0
         
     - name: "Install .NET SDK"
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         global-json-file: "./global.json"
 
@@ -55,7 +55,7 @@ jobs:
         }
 
     - name: release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
       id: create_release
       with:
         draft: false


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs instead of mutable version tags for supply-chain security.

| Action | Previous | SHA |
|---|---|---|
| `actions/checkout` | v6.0.2 | `de0fac2e` |
| `actions/setup-dotnet` | v5.1.0 | `c2fa09f4` |
| `actions/upload-artifact` | v4 | `043fb46d` (v7) |
| `docker/login-action` | v3 | `4907a6dd` (v4) |
| `actions/create-release` | v1 | `0cb9c9b6` |

Supersedes Dependabot PRs #1, #15, #16.