### PR TITLE
Migrate container publishing to GHCR with multi-arch support

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -115,5 +115,16 @@ jobs:
         with:
           global-json-file: "./global.json"
 
+      - name: "Set up Docker"
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
       - name: "Build Container Image"
         run: dotnet publish src/SkillServer/SkillServer.csproj -c Release /t:PublishContainer

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -50,7 +50,7 @@ jobs:
           -c Release \
           /t:PublishContainer \
           /p:ContainerRegistry=${{ env.REGISTRY }} \
-          /p:ContainerRepository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
+          /p:ContainerRepository=${{ env.IMAGE_NAME }} \
           /p:ContainerRuntimeIdentifier=${{ matrix.rid }} \
           /p:ContainerImageTags='"${{ github.ref_name }}-${{ matrix.arch }}"'
 

--- a/src/SkillServer/SkillServer.csproj
+++ b/src/SkillServer/SkillServer.csproj
@@ -5,8 +5,11 @@
     <RootNamespace>SkillServer</RootNamespace>
     <AssemblyName>SkillServer</AssemblyName>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
-    <ContainerRepository>skillserver</ContainerRepository>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <ContainerRepository>netclaw-dev/skillserver</ContainerRepository>
     <ContainerTitle>skillserver</ContainerTitle>
+    <ContainerImageTags>$(VersionPrefix);latest</ContainerImageTags>
+    <ContainerRuntimeIdentifiers>linux-x64;linux-arm64</ContainerRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SkillServer/SkillServer.csproj
+++ b/src/SkillServer/SkillServer.csproj
@@ -10,6 +10,7 @@
     <ContainerTitle>skillserver</ContainerTitle>
     <ContainerImageTags>$(VersionPrefix);latest</ContainerImageTags>
     <ContainerRuntimeIdentifiers>linux-x64;linux-arm64</ContainerRuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add `DockerDefaultTargetOS`, `ContainerRuntimeIdentifiers`, and `ContainerImageTags` to .csproj following DrawTogether pattern
- Fix `ContainerRepository` in publish workflow to avoid duplicating registry path in CLI args
- Enable multi-arch (linux-x64 + linux-arm64) builds for Raspberry Pi support
