### PR TITLE
Fix NuGet publishing workflow and prepare for 0.1.0 release

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -41,7 +41,9 @@ jobs:
       run:  dotnet pack /p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
 
     - name: Push Packages
-      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+      run: |
+        dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.snupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: "Extract latest release notes"
       shell: pwsh
@@ -60,7 +62,7 @@ jobs:
       with:
         draft: false
         prerelease: false
-        release_name: 'Akka.Hosting ${{ github.ref_name }}'
+        release_name: 'SkillServer ${{ github.ref_name }}'
         tag_name: ${{ github.ref }}
         body_path: RELEASE_NOTES_LATEST.md
       env:
@@ -71,4 +73,4 @@ jobs:
       with:
           repo-token: ${{ github.token }}
           release-tag: ${{ github.ref_name }}
-          files: 'output/*.nupkg'
+          files: 'output/*.nupkg;output/*.snupkg'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,23 @@
   <!-- Version Management -->
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <PackageReleaseNotes>Initial release of SkillServer and Netclaw.SkillClient.
+
+**SkillServer**
+- Self-hosted skill registry for AI agent skills
+- AgentSkills.io SKILL.md standard support
+- Cloudflare Agent Skills Discovery RFC v0.2.0 compliance
+- FTS5 full-text search across skill content
+- Content-addressable blob storage (SHA-256)
+- API key authentication for write operations with SHA-256 hashing
+- SQLite-backed metadata with Dapper
+- SDK container support with linux-x64 and linux-arm64 images
+- Batch update checking endpoint
+
+**Netclaw.SkillClient**
+- Typed .NET client library for SkillServer
+- AOT-compatible with source generators
+- Full-text search, version resolution, and batch update checking</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- Default: non-packable unless explicitly set -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SkillServer
 
+[![NuGet](https://img.shields.io/nuget/v/Netclaw.SkillClient)](https://www.nuget.org/packages/Netclaw.SkillClient)
+[![GitHub Container](https://ghcr-badge.egpl.dev/netclaw-dev/skillserver/latest_tag?label=container)](https://ghcr.io/netclaw-dev/skillserver)
+
 A self-hosted skill server for managing AI agent skills internally within organizations. Similar to self-hosted package registries (BaGet for NuGet, Verdaccio for npm, Docker Registry), SkillServer enables companies to:
 
 - Host proprietary skills behind their firewall

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
-#### 1.0.0 April 10th 2025 ####
+#### 0.1.0 April 23rd 2026 ####
 
-Example release notes
+Initial release of SkillServer and Netclaw.SkillClient.
+
+**SkillServer**
+- Self-hosted skill registry for AI agent skills
+- AgentSkills.io SKILL.md standard support
+- Cloudflare Agent Skills Discovery RFC v0.2.0 compliance
+- FTS5 full-text search across skill content
+- Content-addressable blob storage (SHA-256)
+- API key authentication for write operations with SHA-256 hashing
+- SQLite-backed metadata with Dapper
+- SDK container support with linux-x64 and linux-arm64 images
+- Batch update checking endpoint
+
+**Netclaw.SkillClient**
+- Typed .NET client library for SkillServer
+- AOT-compatible with source generators
+- Full-text search, version resolution, and batch update checking


### PR DESCRIPTION
## Summary

- Fix release name from `Akka.Hosting` to `SkillServer` (copy-paste error)
- Push `.snupkg` symbol packages alongside `.nupkg` to NuGet
- Include `.snupkg` in GitHub release assets
- Write real 0.1.0 release notes replacing placeholder content
- Add NuGet and GHCR badges to README
