### PR TITLE
Switch NuGet publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -7,11 +7,13 @@ on:
 
 permissions:
    contents: write
+   id-token: write
 
 jobs:
   publish-nuget:
 
     name: publish-nuget
+    environment: nuget
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -42,8 +44,8 @@ jobs:
 
     - name: Push Packages
       run: |
-        dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
-        dotnet nuget push "output/*.snupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.nupkg" -s https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.snupkg" -s https://api.nuget.org/v3/index.json
 
     - name: "Extract latest release notes"
       shell: pwsh


### PR DESCRIPTION
## Summary

Switch from API key to NuGet trusted publishing (OIDC). Removes the need for `NUGET_KEY` secret.

**Setup required before first publish:**
1. Go to **Settings → Environments** in this repo → create new environment named `nuget`
2. Go to https://www.nuget.org/account/settings → Trusted Publishing → New → select this repo + `nuget` environment
