### PR TITLE
Add OIDC token exchange for NuGet trusted publishing

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -42,10 +42,16 @@ jobs:
     - name: Create Packages
       run:  dotnet pack /p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
 
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push Packages
       run: |
-        dotnet nuget push "output/*.nupkg" -s https://api.nuget.org/v3/index.json
-        dotnet nuget push "output/*.snupkg" -s https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.snupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: "Extract latest release notes"
       shell: pwsh


### PR DESCRIPTION
## Summary

The `publish_nuget.yml` workflow had `id-token: write` permission but was never exchanging the GitHub OIDC token for a temporary NuGet API key. As a result, `dotnet nuget push` fell back to the v2 endpoint and failed with a 401.

## Changes

- Add `NuGet/login@v1` step to exchange OIDC token for short-lived API key
- Pass the temp key via `--api-key` to both `dotnet nuget push` commands

## Root Cause

Without the `NuGet/login` step, there was no API key in scope. `dotnet nuget push` with `-s` but no `--api-key` doesn't use the v3 endpoint for trusted publishing — it falls back to v2 (`https://www.nuget.org/api/v2/package`) which requires a traditional API key.

Fixes the `Publish NuGet` CI job failure from run #24851085466.