### PR TITLE
Add --skip-duplicate to NuGet push commands

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -50,8 +50,8 @@ jobs:
 
     - name: Push Packages
       run: |
-        dotnet nuget push "output/*.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-        dotnet nuget push "output/*.snupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push "output/*.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push "output/*.snupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: "Extract latest release notes"
       shell: pwsh


### PR DESCRIPTION
## Summary

The `*.nupkg` glob matches `.snupkg` files, causing the first push command to upload both the package and its symbols. The second command then tries to push the symbols again and fails with a 409 conflict.

Adding `--skip-duplicate` to both commands prevents this.

## Root Cause

The `.nupkg` push already uploads `.snupkg` symbols automatically. When the `.snupkg` push runs, the symbols are already pending validation on nuget.org.