### PR TITLE
Fix /health endpoint NotSupportedException from source-generated JSON serializer

### DIFF
--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -50,7 +50,9 @@ public static class Endpoints
 
     private static void MapHealthEndpoints(this WebApplication app)
     {
-        app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTimeOffset.UtcNow }));
+        app.MapGet("/health", () => Results.Json(
+            new HealthResponse { Status = "healthy", Timestamp = DateTimeOffset.UtcNow },
+            SkillServerJsonContext.Default.HealthResponse));
     }
 
     private static async Task<IResult> ListSkills(

--- a/src/SkillServer/Models/ApiModels.cs
+++ b/src/SkillServer/Models/ApiModels.cs
@@ -186,3 +186,15 @@ public sealed record ApiKeySummary
     [JsonPropertyName("expiresAt")]
     public DateTimeOffset? ExpiresAt { get; init; }
 }
+
+/// <summary>
+/// Response from the health check endpoint.
+/// </summary>
+public sealed record HealthResponse
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public required DateTimeOffset Timestamp { get; init; }
+}

--- a/src/SkillServer/Models/SkillServerJsonContext.cs
+++ b/src/SkillServer/Models/SkillServerJsonContext.cs
@@ -26,6 +26,7 @@ namespace SkillServer.Models;
 [JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
 [JsonSerializable(typeof(IReadOnlyList<CheckUpdateRequestItem>))]
 [JsonSerializable(typeof(IReadOnlyList<CheckUpdateResponseItem>))]
+[JsonSerializable(typeof(HealthResponse))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -30,6 +30,11 @@ public sealed class SkillServerIntegrationTests
         var response = await _fixture.HttpClient.GetAsync("/health", ct);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<SkillServer.Models.HealthResponse>(ct);
+        Assert.NotNull(body);
+        Assert.Equal("healthy", body.Status);
+        Assert.True(body.Timestamp > DateTimeOffset.MinValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fixes #37 — `/health` endpoint was returning an anonymous type not supported by `SkillServerJsonContext`, causing `NotSupportedException` at runtime
- Introduces `HealthResponse` record in `ApiModels.cs` with proper `[JsonPropertyName]` attributes
- Registers `HealthResponse` in the source-generated JSON serializer context
- Updates endpoint to use `Results.Json()` with the context's type info resolver

## Changes

| File | Change |
|------|--------|
| `Models/ApiModels.cs` | Added `HealthResponse` sealed record |
| `Models/SkillServerJsonContext.cs` | Added `[JsonSerializable(typeof(HealthResponse))]` |
| `Endpoints.cs` | Changed from `Results.Ok(anonymous)` to `Results.Json(healthResponse, context.HealthResponse)` |

All 65 tests pass (48 unit + 17 integration), build produces 0 warnings.