### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>agent-skills;ai;skills;skill-server;netclaw</PackageTags>
   </PropertyGroup>
-
   <!-- C# Language Settings -->
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
@@ -19,40 +18,27 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>Initial release of SkillServer and Netclaw.SkillClient.
+    <VersionPrefix>0.1.1</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes**
+- Fix /health endpoint NotSupportedException from source-generated JSON serializer (#39)
 
-**SkillServer**
-- Self-hosted skill registry for AI agent skills
-- AgentSkills.io SKILL.md standard support
-- Cloudflare Agent Skills Discovery RFC v0.2.0 compliance
-- FTS5 full-text search across skill content
-- Content-addressable blob storage (SHA-256)
-- API key authentication for write operations with SHA-256 hashing
-- SQLite-backed metadata with Dapper
-- SDK container support with linux-x64 and linux-arm64 images
-- Batch update checking endpoint
+**CI/CD**
+- Add --skip-duplicate to NuGet push commands to prevent duplicate package errors (#36)
 
-**Netclaw.SkillClient**
-- Typed .NET client library for SkillServer
-- AOT-compatible with source generators
-- Full-text search, version resolution, and batch update checking</PackageReleaseNotes>
+**Dependency Updates**
+- Bump YamlDotNet from 16.3.0 to 17.0.1 (#38)</PackageReleaseNotes>
   </PropertyGroup>
-
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <!-- Target Framework Definitions -->
   <PropertyGroup>
     <NetLibVersion>net10.0</NetLibVersion>
     <NetTestVersion>net10.0</NetTestVersion>
   </PropertyGroup>
-
   <!-- SourceLink Configuration -->
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -60,17 +46,14 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
-
   <!-- NuGet Package Assets -->
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)netclaw-icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-
   <PropertyGroup>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>netclaw-icon.png</PackageIcon>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 0.1.1 April 24th 2026 ####
+
+**Bug Fixes**
+- Fix /health endpoint NotSupportedException from source-generated JSON serializer (#39)
+
+**CI/CD**
+- Add --skip-duplicate to NuGet push commands to prevent duplicate package errors (#36)
+
+**Dependency Updates**
+- Bump YamlDotNet from 16.3.0 to 17.0.1 (#38)
+
 #### 0.1.0 April 23rd 2026 ####
 
 Initial release of SkillServer and Netclaw.SkillClient.


### PR DESCRIPTION
## Summary

Prepare the 0.1.1 patch release.

### Changes
- Fix /health endpoint NotSupportedException from source-generated JSON serializer (#39)
- Add --skip-duplicate to NuGet push commands (#36)
- Bump YamlDotNet from 16.3.0 to 17.0.1 (#38)