### PR TITLE
Return 409 Conflict for duplicate skill version uploads (#41)

### DIFF
--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Endpoints.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -232,6 +232,15 @@ public static class Endpoints
 
         if (!result.Success)
         {
+            if (result.IsDuplicateVersion)
+            {
+                return Results.Conflict(new ErrorResponse
+                {
+                    Error = "duplicate_version",
+                    Message = result.Error ?? "Version already exists."
+                });
+            }
+
             return Results.BadRequest(new ErrorResponse
             {
                 Error = "upload_failed",

--- a/src/SkillServer/Services/SkillUploadService.cs
+++ b/src/SkillServer/Services/SkillUploadService.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SkillUploadService.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -91,7 +91,7 @@ public sealed partial class SkillUploadService
             var existingVersion = await _repository.GetVersionAsync(skillId, version.Value, ct);
             if (existingVersion is not null)
             {
-                return SkillUploadResult.Failed($"Version {version.Value} already exists for skill {name.Value}.");
+                return SkillUploadResult.DuplicateVersion($"Version {version.Value} already exists for skill {name.Value}.");
             }
         }
 
@@ -181,12 +181,16 @@ public sealed record SkillUploadResult
     public SkillVersionString? Version { get; init; }
     public Sha256Digest? Digest { get; init; }
     public string? Error { get; init; }
+    public bool IsDuplicateVersion { get; init; }
 
     public static SkillUploadResult Succeeded(SkillName name, SkillVersionString version, Sha256Digest digest) =>
         new() { Success = true, Name = name, Version = version, Digest = digest };
 
     public static SkillUploadResult Failed(string error) =>
         new() { Success = false, Error = error };
+
+    public static SkillUploadResult DuplicateVersion(string error) =>
+        new() { Success = false, Error = error, IsDuplicateVersion = true };
 }
 
 /// <summary>

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SkillServerIntegrationTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -480,5 +480,95 @@ public sealed class SkillServerIntegrationTests
 
         var response = await _fixture.HttpClient.GetAsync("/api-keys", ct);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UploadSkill_DuplicateVersion_Returns409()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"dup-test-{Guid.NewGuid():N}"[..20];
+
+        var skillContent = $"""
+            ---
+            name: {skillName}
+            description: Testing duplicate version
+            ---
+
+            # Duplicate Test
+            """;
+
+        // Upload the first version
+        using var content1 = new MultipartFormDataContent();
+        content1.Add(new StringContent(skillName), "name");
+        content1.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent));
+        fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content1.Add(fileContent1, "file", "SKILL.md");
+
+        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse1.StatusCode);
+
+        // Upload the same version again - should return 409 Conflict
+        using var content2 = new MultipartFormDataContent();
+        content2.Add(new StringContent(skillName), "name");
+        content2.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent));
+        fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content2.Add(fileContent2, "file", "SKILL.md");
+
+        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        Assert.Equal(HttpStatusCode.Conflict, uploadResponse2.StatusCode);
+
+        // Verify the response body contains the duplicate_version error
+        var errorBody = await uploadResponse2.Content.ReadFromJsonAsync<SkillServer.Models.ErrorResponse>(ct);
+        Assert.NotNull(errorBody);
+        Assert.Equal("duplicate_version", errorBody.Error);
+        Assert.Contains("already exists", errorBody.Message!);
+    }
+
+    [Fact]
+    public async Task UploadSkill_DifferentVersions_AreAllowed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"ver-test-{Guid.NewGuid():N}"[..20];
+
+        var skillContent = $"""
+            ---
+            name: {skillName}
+            description: Testing different versions
+            ---
+
+            # Version Test
+            """;
+
+        // Upload v1.0.0
+        using var content1 = new MultipartFormDataContent();
+        content1.Add(new StringContent(skillName), "name");
+        content1.Add(new StringContent("1.0.0"), "version");
+
+        var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent));
+        fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content1.Add(fileContent1, "file", "SKILL.md");
+
+        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse1.StatusCode);
+
+        // Upload v2.0.0 - should succeed
+        using var content2 = new MultipartFormDataContent();
+        content2.Add(new StringContent(skillName), "name");
+        content2.Add(new StringContent("2.0.0"), "version");
+
+        var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent));
+        fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content2.Add(fileContent2, "file", "SKILL.md");
+
+        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse2.StatusCode);
+
+        // Verify both versions exist
+        var versions = await _fixture.Client.GetSkillVersionsAsync(skillName, ct);
+        Assert.Equal(2, versions.Count);
     }
 }


### PR DESCRIPTION
## Summary

Return **409 Conflict** instead of 400 Bad Request when uploading a skill version that already exists.

Follows the same pattern as NuGet — clients can use HTTP status codes alone for idempotent publish pipelines:

| Status | Meaning |
|--------|---------|
| 201 | Published successfully |
| 409 | Already exists (skip, no-op) |
| 400 | Actual validation error |
| 401/403 | Auth problem |

## Changes

### `src/SkillServer/Services/SkillUploadService.cs`
- Added `IsDuplicateVersion` flag to `SkillUploadResult`
- Added `SkillUploadResult.DuplicateVersion(error)` factory method
- Version-exists check now returns `DuplicateVersion(...)` instead of `Failed(...)`

### `src/SkillServer/Endpoints.cs`
- `UploadSkill` handler: if `result.IsDuplicateVersion` → return `Results.Conflict(409)` with error code `duplicate_version`
- Other validation errors still return 400 as before

### `tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs`
- `UploadSkill_DuplicateVersion_Returns409` — verifies 409 response with correct error code
- `UploadSkill_DifferentVersions_AreAllowed` — verifies v1.0.0 and v2.0.0 both succeed

## Motivation

Enables idempotent skill publishing in CI/CD pipelines (petabridge-skills) without fragile response-body parsing.

Closes #41