### PR TITLE
Prepare for 0.1.2 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,15 +20,10 @@
   </PropertyGroup>
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes**
-- Fix /health endpoint NotSupportedException from source-generated JSON serializer (#39)
-
-**CI/CD**
-- Add --skip-duplicate to NuGet push commands to prevent duplicate package errors (#36)
-
-**Dependency Updates**
-- Bump YamlDotNet from 16.3.0 to 17.0.1 (#38)</PackageReleaseNotes>
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>**Improvements**
+- Return 409 Conflict for duplicate skill version uploads instead of 400 Bad Request (#41)
+  - Follows NuGet pattern — enables idempotent publish pipelines via --skip-duplicate semantics</PackageReleaseNotes>
   </PropertyGroup>
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 0.1.2 April 27th 2026 ####
+
+**Improvements**
+- Return 409 Conflict for duplicate skill version uploads instead of 400 Bad Request (#41)
+  - Follows NuGet pattern — enables idempotent publish pipelines via `--skip-duplicate` semantics
+
 #### 0.1.1 April 24th 2026 ####
 
 **Bug Fixes**


### PR DESCRIPTION
## Changes

- Return 409 Conflict for duplicate skill version uploads instead of 400 Bad Request (#41)
  - Follows NuGet pattern — enables idempotent publish pipelines via `--skip-duplicate` semantics

## Release Prep

- Update `Directory.Build.props` version to 0.1.2
- Update `RELEASE_NOTES.md` with 0.1.2 changelog

After merge, I will push the `0.1.2` tag to trigger NuGet + Docker publishing.