### PR TITLE
Fix invalid SHA pin for actions/github-script in publish workflow

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -84,7 +84,7 @@ jobs:
           files: 'output/*.nupkg;output/*.snupkg'
 
     - name: Publish Release
-      uses: actions/github-script@60a0e5936f594fbea0d3df1b631a1473a628e635
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
       with:
         script: |
           await github.rest.repos.updateRelease({


### PR DESCRIPTION
## Summary
- The `publish_nuget.yml` workflow pinned `actions/github-script` to a non-existent commit SHA (`60a0e593...`), which is a near-miss of the real v7.0.1 SHA (`60a0d830...`)
- Updated to pin to v7.1.0 (`f28e40c7...`), the latest v7.x release
- This caused the 0.1.2 release to fail at the "Set up job" stage

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, re-tag `0.1.2` and confirm the publish workflow completes