### PR TITLE
Replace fragile release steps with gh release create

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -64,34 +64,11 @@ jobs:
           $content | Set-Content RELEASE_NOTES_LATEST.md
         }
 
-    - name: Create Release (draft)
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
-      id: create_release
-      with:
-        draft: true
-        prerelease: false
-        release_name: 'SkillServer ${{ github.ref_name }}'
-        tag_name: ${{ github.ref }}
-        body_path: RELEASE_NOTES_LATEST.md
+    - name: Create GitHub Release
+      run: |
+        gh release create "${{ github.ref_name }}" \
+          --title "SkillServer ${{ github.ref_name }}" \
+          --notes-file RELEASE_NOTES_LATEST.md \
+          output/*.nupkg output/*.snupkg
       env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: Upload Release Assets
-      uses: AButler/upload-release-assets@v3.0
-      with:
-          repo-token: ${{ github.token }}
-          release-tag: ${{ github.ref_name }}
-          files: 'output/*.nupkg;output/*.snupkg'
-
-    - name: Publish Release
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
-      with:
-        script: |
-          await github.rest.repos.updateRelease({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            release_id: ${{ steps.create_release.outputs.id }},
-            draft: false
-          });
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- The three-step release flow (create draft → upload assets by tag → publish) is structurally broken: `AButler/upload-release-assets` can't find draft releases by tag, causing a `Not Found` error every time
- Replaced all three steps with a single `gh release create` call that atomically creates the release and uploads `.nupkg`/`.snupkg` assets
- Removes dependencies on `actions/create-release`, `AButler/upload-release-assets`, and `actions/github-script`

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag `0.1.2` and confirm the full publish workflow succeeds