### PR TITLE
Fix CLI NuGet package ID and link component READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repository contains three components:
 | Component | Description | Install |
 |-----------|-------------|---------|
 | **SkillServer** | Self-hosted skill registry (web server) | `docker pull ghcr.io/netclaw-dev/skillserver` |
-| **skillserver CLI** | Command-line tool for publishing and managing skills | `dotnet tool install -g Netclaw.SkillServer.Cli` |
-| **Netclaw.SkillClient** | Typed .NET client library | `dotnet add package Netclaw.SkillClient` |
+| **[skillserver CLI](src/Netclaw.SkillServer.Cli/README.md)** | Command-line tool for publishing and managing skills | `dotnet tool install -g Netclaw.SkillServer.Cli` |
+| **[Netclaw.SkillClient](src/Netclaw.SkillClient/README.md)** | Typed .NET client library | `dotnet add package Netclaw.SkillClient` |
 
 ## Standards Support
 

--- a/src/Netclaw.SkillServer.Cli/Netclaw.SkillServer.Cli.csproj
+++ b/src/Netclaw.SkillServer.Cli/Netclaw.SkillServer.Cli.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetLibVersion)</TargetFramework>
+    <PackageId>Netclaw.SkillServer.Cli</PackageId>
     <AssemblyName>skillserver</AssemblyName>
     <RootNamespace>Netclaw.SkillServer.Cli</RootNamespace>
     <Description>CLI tool for publishing and managing skills on a SkillServer instance.</Description>


### PR DESCRIPTION
## Summary

- Set explicit `<PackageId>Netclaw.SkillServer.Cli</PackageId>` so the NuGet package matches the documented `dotnet tool install -g Netclaw.SkillServer.Cli` command (previously defaulted to `skillserver` from AssemblyName)
- Link component names in root README table to their respective READMEs

## Test plan

- [x] `dotnet pack` produces `Netclaw.SkillServer.Cli.0.2.1.nupkg` (verified locally)