### PR TITLE
Fix MSBuild property syntax for Windows CI

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -144,8 +144,8 @@ jobs:
             -c Release \
             -r linux-x64 \
             --self-contained \
-            /p:PublishSingleFile=true \
-            /p:TrimmerSingleWarn=false \
+            -p:PublishSingleFile=true \
+            -p:TrimmerSingleWarn=false \
             -o ./publish/linux-x64
 
       - name: "Check trim warnings"
@@ -154,12 +154,12 @@ jobs:
             -c Release \
             -r linux-x64 \
             --self-contained \
-            /p:PublishSingleFile=true \
-            /p:TrimmerSingleWarn=false \
-            /p:TreatWarningsAsErrors=true \
-            /warnAsError:IL2026 /warnAsError:IL2057 \
-            /warnAsError:IL2067 /warnAsError:IL2075 \
-            /warnAsError:IL2096 /warnAsError:IL3050
+            -p:PublishSingleFile=true \
+            -p:TrimmerSingleWarn=false \
+            -p:TreatWarningsAsErrors=true \
+            -warnAsError:IL2026 -warnAsError:IL2057 \
+            -warnAsError:IL2067 -warnAsError:IL2075 \
+            -warnAsError:IL2096 -warnAsError:IL3050
 
       - name: "Smoke test"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./build.ps1
 
     - name: "Pack"
-      run: dotnet pack /p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
+      run: dotnet pack -p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
 
     - name: "Upload artifacts"
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -108,10 +108,10 @@ jobs:
           -c Release \
           -r ${{ matrix.rid }} \
           --self-contained \
-          /p:PublishSingleFile=true \
-          /p:Version=${{ env.VERSION }} \
-          /p:AssemblyVersion=${{ env.ASSEMBLY_VERSION }} \
-          /p:FileVersion=${{ env.ASSEMBLY_VERSION }} \
+          -p:PublishSingleFile=true \
+          -p:Version=${{ env.VERSION }} \
+          -p:AssemblyVersion=${{ env.ASSEMBLY_VERSION }} \
+          -p:FileVersion=${{ env.ASSEMBLY_VERSION }} \
           -o ./publish
 
     - name: "Smoke test"
@@ -187,11 +187,11 @@ jobs:
       run: |
         dotnet publish src/SkillServer/SkillServer.csproj \
           -c Release \
-          /t:PublishContainer \
-          /p:ContainerRegistry=${{ env.CONTAINER_REGISTRY }} \
-          /p:ContainerRepository=${{ env.CONTAINER_IMAGE }} \
-          /p:ContainerRuntimeIdentifier=${{ matrix.rid }} \
-          /p:ContainerImageTags='"${{ github.ref_name }}-${{ matrix.arch }}"'
+          -t:PublishContainer \
+          -p:ContainerRegistry=${{ env.CONTAINER_REGISTRY }} \
+          -p:ContainerRepository=${{ env.CONTAINER_IMAGE }} \
+          -p:ContainerRuntimeIdentifier=${{ matrix.rid }} \
+          -p:ContainerImageTags='"${{ github.ref_name }}-${{ matrix.arch }}"'
 
   # ─── Stage 2: Publish everything once all builds succeed ─────────────
 


### PR DESCRIPTION
## Summary
- Replace `/p:` and `/t:` with `-p:` and `-t:` in all workflow files
- Git Bash on Windows strips leading `/` from arguments, causing MSBuild to misinterpret `/p:PublishSingleFile=true` as a project path
- This caused the `CLI-win-x64` job to fail in the 0.3.0 release workflow

## Test plan
- [ ] PR validation passes (especially CLI Publish Dry Run)
- [ ] Re-run 0.3.0 release after merge