### PR TITLE
Prepare for 0.3.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,20 +20,12 @@
   </PropertyGroup>
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <PackageReleaseNotes>**New Features**
-- Add `skillserver` CLI tool for publishing and managing skills from the command line (#56)
-  - Commands: `publish`, `publish-all`, `delete`, `list`, `versions`, `verify`, `config`, `api-key`
-  - Distributed as a .NET global tool (`dotnet tool install -g Netclaw.SkillServer.Cli`) and standalone trimmed binaries for linux-x64, linux-arm64, osx-arm64, and win-x64
-  - Install scripts for Linux/macOS (`install-skillserver.sh`) and Windows (`install-skillserver.ps1`)
-- Add `UploadSkillWithResourcesAsync` and `UploadSkillIfNotExistsAsync` to `Netclaw.SkillClient` for idempotent publishing with resource file support (#56)
+- Add `lint` command to CLI — validates local skills against the AgentSkills.io spec without requiring a server connection (#68)
 
-**Improvements**
-- Consolidate `publish_nuget.yml` and `publish_container.yml` into a unified `release.yml` workflow — NuGet packages, CLI binaries, and container images build in parallel with a single coordinated publish stage (#56)
-- Add CLI publish dry-run, trim warning checks, and install script linting to PR validation (#56)
-
-**Dependency Updates**
-- Bump YamlDotNet from 17.0.1 to 17.1.0 (#55)</PackageReleaseNotes>
+**Bug Fixes**
+- Fix unbound variable error in `install-skillserver.sh` — resolves installation failures on strict Bash environments (#60)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 0.3.1 May 15th 2026 ####
+
+**New Features**
+- Add `lint` command to CLI — validates local skills against the AgentSkills.io spec without requiring a server connection (#68)
+
+**Bug Fixes**
+- Fix unbound variable error in `install-skillserver.sh` — resolves installation failures on strict Bash environments (#60)
+
 #### 0.3.0 May 5th 2026 ####
 
 **New Features**


### PR DESCRIPTION
Release notes in [RELEASE_NOTES.md](https://github.com/Aaronontheweb/skill-server/blob/release/0.3.1/RELEASE_NOTES.md)