### PR TITLE
fix(deps): suppress GHSA-2m69 and pin MessagePack 2.5.301

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,4 +40,20 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
   </ItemGroup>
+  <!-- Transitive security pin: Aspire.Hosting.AppHost → StreamJsonRpc pulls in
+       MessagePack 2.5.192, flagged by NuGetAudit (GHSA-hv8m-jj95-wg3x, LZ4
+       decompression DoS). Pin to the patched v2 (2.5.301) to clear the audit. -->
+  <ItemGroup>
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
+  </ItemGroup>
+  <!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11
+       is flagged by NuGetAudit (GHSA-2m69-gcr7-jv3q, CVE-2025-6965 — SQLite < 3.50.2
+       memory corruption in aggregate-term handling). No patched version of
+       SQLitePCLRaw.lib.e_sqlite3 is available on NuGet: 3.50.3 was published then unlisted,
+       and 2.1.11 remains the latest stable release. This suppress will be removed once
+       Microsoft ships a Microsoft.Data.Sqlite release that pins a non-vulnerable
+       SQLitePCLRaw.lib.e_sqlite3. Track: https://github.com/dotnet/efcore/issues/38257 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>

--- a/src/SkillServer.AppHost/SkillServer.AppHost.csproj
+++ b/src/SkillServer.AppHost/SkillServer.AppHost.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="YamlDotNet" />
+    <!-- Pin MessagePack to suppress GHSA-hv8m-jj95-wg3x (transitive from Aspire → StreamJsonRpc) -->
+    <PackageReference Include="MessagePack" />
     <ProjectReference Include="..\SkillServer\SkillServer.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Motivation

These are the same dependency fixes we already applied to the main netclaw repo (PR #1444). They're needed to unblock the Dependabot PR queue:

- **MessagePack 2.5.301**: Pin direct dependency in AppHost so the central version pin in Directory.Packages.props takes effect, suppressing GHSA-hv8m-jj95-wg3x (LZ4 decompression DoS from transitive StreamJsonRpc dep)
- **SQLitePCLRaw.lib.e_sqlite3**: Add NuGetAuditSuppress for GHSA-2m69-gcr7-jv3q (CVE-2025-6965) — no patched version available on NuGet yet

Once this lands, all 9 Dependabot PRs should pass CI.

## References
- https://github.com/dotnet/efcore/issues/38257
- Main netclaw fix: PR #1444