### PR TITLE
Document native manifest and sub-agent sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ This repository contains three components:
 
 ## Standards Support
 
-SkillServer implements two complementary standards:
+SkillServer implements Agent Skills standards and defines native extensions for NetClaw-aware clients:
 
 - **[AgentSkills.io](https://agentskills.io)** - The SKILL.md format standard (originally by Anthropic)
 - **[Cloudflare Agent Skills Discovery RFC v0.2.0](https://github.com/cloudflare/agent-skills-discovery-rfc)** - Discovery via `/.well-known/agent-skills/index.json`
+- **[SkillServer specifications](docs/specs/README.md)** - Native skill, sub-agent, and manifest sync specs
+
+## Specifications
+
+| Specification | Purpose |
+|---------------|---------|
+| [Skill Packages](docs/specs/skills.md) | How to author and publish AgentSkills.io-compatible SkillServer skills. |
+| [Sub-Agent Packages](docs/specs/subagents.md) | How NetClaw sub-agent definitions are authored and how SkillServer will publish them. |
+| [Native Manifest](docs/specs/native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future native resources. |
+| [Sub-Agent Sync Epic](docs/epics/subagent-sync.md) | Requirements and proposed GitHub issue breakdown for native manifest and sub-agent sync. |
 
 ## Quick Start
 
@@ -59,7 +69,7 @@ Configuration is via environment variables or `appsettings.json`:
 | Endpoint | Description |
 |----------|-------------|
 | `GET /.well-known/agent-skills/index.json` | RFC-compliant skill index |
-| `GET /manifest.json` | NetClaw-compatible manifest |
+| `GET /manifest.json` | Planned NetClaw-native manifest; see [Native Manifest](docs/specs/native-manifest.md) |
 
 ### Skills
 
@@ -165,10 +175,12 @@ See the [client library README](src/Netclaw.SkillClient/README.md) for full API 
 
 ## NetClaw Integration
 
-Add SkillServer as a skill source:
+Current NetClaw feed sync uses the RFC skill discovery endpoint. The planned native manifest will add richer skill metadata and sub-agent sync.
+
+Add SkillServer as a skill source using the configured feed URL for your NetClaw version:
 
 ```bash
-netclaw skill source add my-server --feed http://localhost:8080/manifest.json
+netclaw skill source add my-server --feed http://localhost:8080
 ```
 
 ## Development

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -10,7 +10,12 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 |----------|----------|---------|
 | AgentSkills.io | SKILL.md format | Skill definition format |
 | Cloudflare RFC v0.2.0 | `/.well-known/agent-skills/index.json` | Discovery protocol |
-| NetClaw manifest | `/manifest.json` | NetClaw CLI compatibility |
+
+## Planned Native Extensions
+
+| Extension | Endpoint | Purpose |
+|-----------|----------|---------|
+| NetClaw native manifest | `/manifest.json` | Rich paginated sync feed for skills and sub-agents |
 
 ## Architecture
 
@@ -19,13 +24,13 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 │                        SkillServer                          │
 ├─────────────────────────────────────────────────────────────┤
 │  Minimal APIs (Endpoints.cs)                                │
-│    ├── Discovery: RFC index, NetClaw manifest               │
+│    ├── Discovery: RFC index                                 │
 │    ├── Skills: CRUD operations                              │
 │    └── Blobs: Content-addressable storage                   │
 ├─────────────────────────────────────────────────────────────┤
 │  Services                                                   │
 │    ├── SkillUploadService - Upload handling, validation     │
-│    ├── IndexGenerator - RFC/NetClaw index generation        │
+│    ├── IndexGenerator - RFC index generation                │
 │    └── BlobStorage - Content-addressable file storage       │
 ├─────────────────────────────────────────────────────────────┤
 │  Data                                                       │
@@ -69,7 +74,7 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 ## Current State (v0.1.0)
 
 - Full CRUD for skills with versioning
-- RFC and NetClaw discovery endpoints
+- RFC discovery endpoint
 - Content-addressable blob storage
 - 52 tests passing (45 unit + 7 integration)
 - Multi-arch container publishing
@@ -80,3 +85,5 @@ SkillServer is a self-hosted skill registry for AI agents, enabling organization
 - Rate limiting
 - Audit logging
 - Webhook notifications
+- Native manifest for richer NetClaw sync
+- Sub-agent definition publishing and sync

--- a/docs/epics/subagent-sync.md
+++ b/docs/epics/subagent-sync.md
@@ -34,6 +34,7 @@ NetClaw already has a sub-agent format and skill-to-sub-agent routing through `m
 - CLI tooling can validate sub-agent definitions before publication.
 - Sync is safe: digest-verified, failure-tolerant, and non-destructive to user-authored local files.
 - Sync destinations are client-controlled; the server manifest never prescribes local filesystem paths.
+- Non-NetClaw clients consume sub-agents through adapters that map portable `agent-md` artifacts into their own local formats.
 
 ## Non-Goals
 
@@ -147,6 +148,8 @@ Deliverables:
 
 - `Netclaw.SkillClient` methods for native manifest traversal.
 - Sub-agent upload/download client methods.
+- Destination-agnostic sync primitives for verified artifact download.
+- Adapter guidance for non-NetClaw clients that need to map `agent-md` into a different local agent format.
 - NetClaw daemon sync support for native manifest sub-agent resources.
 - Local sync state for sub-agents.
 - Safe install path for server-synced sub-agent files.
@@ -154,6 +157,7 @@ Deliverables:
 Acceptance criteria:
 
 - NetClaw can sync sub-agents from SkillServer without overwriting user-authored files.
+- Non-NetClaw clients can reuse the library and provide their own destination/format adapters.
 - NetClaw can resolve skill `metadata.subagent` targets after sync.
 - Failed sync keeps existing local sub-agents.
 - Removed server-side sub-agents are pruned only after a confirmed successful feed sync.
@@ -311,11 +315,14 @@ Tasks:
 - [ ] Add skill manifest traversal helpers.
 - [ ] Add sub-agent manifest traversal helpers.
 - [ ] Add upload/download methods for sub-agent definitions.
+- [ ] Add destination-agnostic helpers for verified artifact download.
+- [ ] Document how non-NetClaw clients can provide destination and format adapters.
 - [ ] Preserve AOT source-generated serialization.
 
 Acceptance criteria:
 - Client can fetch root manifest and follow collection links.
 - Client can download a sub-agent artifact and verify digest.
+- Client APIs do not hard-code NetClaw application paths.
 - Existing RFC client methods remain unchanged.
 ```
 

--- a/docs/epics/subagent-sync.md
+++ b/docs/epics/subagent-sync.md
@@ -33,6 +33,7 @@ NetClaw already has a sub-agent format and skill-to-sub-agent routing through `m
 - The native manifest uses linked path-based pagination instead of query-string cursor contracts.
 - CLI tooling can validate sub-agent definitions before publication.
 - Sync is safe: digest-verified, failure-tolerant, and non-destructive to user-authored local files.
+- Sync destinations are client-controlled; the server manifest never prescribes local filesystem paths.
 
 ## Non-Goals
 
@@ -356,6 +357,7 @@ Tasks:
 - [ ] Sync sub-agent `agent-md` artifacts into a managed server-feed location.
 - [ ] Track sub-agent sync state by feed, name, version, and digest.
 - [ ] Preserve user-authored local sub-agent files.
+- [ ] Keep local sync destinations client-configurable or clearly scoped to the NetClaw home directory.
 - [ ] Ensure skill `metadata.subagent` targets resolve after sync.
 
 Acceptance criteria:

--- a/docs/epics/subagent-sync.md
+++ b/docs/epics/subagent-sync.md
@@ -35,6 +35,7 @@ NetClaw already has a sub-agent format and skill-to-sub-agent routing through `m
 - Sync is safe: digest-verified, failure-tolerant, and non-destructive to user-authored local files.
 - Sync destinations are client-controlled; the server manifest never prescribes local filesystem paths.
 - Non-NetClaw clients consume sub-agents through adapters that map portable `agent-md` artifacts into their own local formats.
+- CLI and client-library sync primitives are destination-agnostic for both skills and sub-agents.
 
 ## Non-Goals
 
@@ -150,6 +151,7 @@ Deliverables:
 - Sub-agent upload/download client methods.
 - Destination-agnostic sync primitives for verified artifact download.
 - Adapter guidance for non-NetClaw clients that need to map `agent-md` into a different local agent format.
+- CLI sync behavior for sub-agents that mirrors the unopinionated skill sync model.
 - NetClaw daemon sync support for native manifest sub-agent resources.
 - Local sync state for sub-agents.
 - Safe install path for server-synced sub-agent files.
@@ -158,6 +160,7 @@ Acceptance criteria:
 
 - NetClaw can sync sub-agents from SkillServer without overwriting user-authored files.
 - Non-NetClaw clients can reuse the library and provide their own destination/format adapters.
+- OpenCode or other future clients can be supported without changing the server manifest shape.
 - NetClaw can resolve skill `metadata.subagent` targets after sync.
 - Failed sync keeps existing local sub-agents.
 - Removed server-side sub-agents are pruned only after a confirmed successful feed sync.
@@ -317,12 +320,14 @@ Tasks:
 - [ ] Add upload/download methods for sub-agent definitions.
 - [ ] Add destination-agnostic helpers for verified artifact download.
 - [ ] Document how non-NetClaw clients can provide destination and format adapters.
+- [ ] Ensure helper APIs do not assume NetClaw application paths or formats.
 - [ ] Preserve AOT source-generated serialization.
 
 Acceptance criteria:
 - Client can fetch root manifest and follow collection links.
 - Client can download a sub-agent artifact and verify digest.
 - Client APIs do not hard-code NetClaw application paths.
+- Client APIs can be reused by an OpenCode or other non-NetClaw sync adapter.
 - Existing RFC client methods remain unchanged.
 ```
 

--- a/docs/epics/subagent-sync.md
+++ b/docs/epics/subagent-sync.md
@@ -1,0 +1,388 @@
+# Epic: Native Manifest And Sub-Agent Sync
+
+Status: planning.
+
+This epic delivers a SkillServer-native sync model for skills and NetClaw sub-agent definitions while keeping the Cloudflare Agent Skills Discovery RFC feed compatible.
+
+GitHub tracking:
+
+- Epic: [#84](https://github.com/netclaw-dev/skill-server/issues/84)
+- Specs: [#85](https://github.com/netclaw-dev/skill-server/issues/85)
+- RFC artifact alignment: [#86](https://github.com/netclaw-dev/skill-server/issues/86)
+- Native manifest skills collection: [#87](https://github.com/netclaw-dev/skill-server/issues/87)
+- Sub-agent storage and artifact endpoints: [#88](https://github.com/netclaw-dev/skill-server/issues/88)
+- Sub-agent manifest collection: [#89](https://github.com/netclaw-dev/skill-server/issues/89)
+- Client support: [#90](https://github.com/netclaw-dev/skill-server/issues/90)
+- CLI support: [#91](https://github.com/netclaw-dev/skill-server/issues/91)
+- NetClaw sync integration: [#92](https://github.com/netclaw-dev/skill-server/issues/92)
+- Security and compatibility hardening: [#93](https://github.com/netclaw-dev/skill-server/issues/93)
+
+## Problem
+
+SkillServer currently publishes one implemented discovery document: `/.well-known/agent-skills/index.json`. It also exposes first-party `/skills` APIs, but there is no implemented `/manifest.json` native feed despite README references.
+
+NetClaw already has a sub-agent format and skill-to-sub-agent routing through `metadata.subagent`. SkillServer cannot publish or sync those sub-agent definitions today.
+
+## Product Requirements
+
+- Generic AgentSkills.io clients can continue using the RFC feed without understanding SkillServer extensions.
+- NetClaw-aware clients can sync skills and sub-agent definitions from one native entry point.
+- Skill version details in the native feed reuse the same artifact object exposed by the RFC feed.
+- Sub-agents are first-class native resources, not fake skills.
+- Skill-to-sub-agent binding uses existing `metadata.subagent` frontmatter.
+- The native manifest uses linked path-based pagination instead of query-string cursor contracts.
+- CLI tooling can validate sub-agent definitions before publication.
+- Sync is safe: digest-verified, failure-tolerant, and non-destructive to user-authored local files.
+
+## Non-Goals
+
+- No general package dependency graph in the first release.
+- No sub-agent entries in the Cloudflare RFC skill feed.
+- No archive-based sub-agent packages until there is a concrete resource bundling need.
+- No automatic context loading of every related skill or sub-agent.
+
+## Delivery Phases
+
+### Phase 1: Specifications And Compatibility Rules
+
+Define the public contracts before implementation.
+
+Deliverables:
+
+- Skill package spec.
+- Sub-agent package spec.
+- Native manifest spec.
+- README links.
+- Documented current implementation gaps.
+
+Acceptance criteria:
+
+- Specs describe how to author skills and sub-agents.
+- Specs state that `metadata.subagent` is a route, not a dependency.
+- Specs state that native skill details reuse the RFC artifact shape.
+- Specs state that `/manifest.json` is planned until implemented.
+
+### Phase 2: RFC Artifact Alignment For Skills
+
+Bring SkillServer's skill artifact model closer to the Cloudflare RFC.
+
+Deliverables:
+
+- Archive artifact generation for skills with resources.
+- Archive download endpoint for versioned skills.
+- RFC index emits `type: "archive"` for resourceful skills.
+- Existing per-file resource routes remain available for compatibility.
+
+Acceptance criteria:
+
+- `skill-md` entries digest the raw `SKILL.md` bytes.
+- `archive` entries digest the raw archive bytes.
+- Archives contain `SKILL.md` at the root.
+- Archive paths reject traversal and absolute paths.
+- Existing resource tests keep passing or have explicit compatibility replacements.
+
+### Phase 3: Native Manifest API
+
+Implement the linked native feed.
+
+Deliverables:
+
+- `GET /manifest.json` root document.
+- Skills collection index and pages.
+- Skill identity index and version detail endpoints.
+- Source-generated JSON models.
+- Integration tests for link traversal.
+
+Acceptance criteria:
+
+- Clients can discover skill identities without using query strings.
+- Clients can follow links from root to version detail.
+- Skill version detail embeds the same artifact fields as the RFC feed.
+- Unknown future collections can be ignored by older clients.
+
+### Phase 4: Sub-Agent Registry Support
+
+Add sub-agent storage, upload, download, and native manifest projection.
+
+Deliverables:
+
+- Sub-agent domain models and SQLite schema.
+- Markdown parser/validator matching NetClaw's current format.
+- `POST /subagents` upload endpoint.
+- `GET /subagents/{name}/{version}/agent.md` artifact endpoint.
+- Delete/version metadata endpoints as needed.
+- Native manifest sub-agent collection, identity, and version detail endpoints.
+
+Acceptance criteria:
+
+- Invalid sub-agent markdown is rejected with actionable errors.
+- Duplicate sub-agent versions conflict deterministically.
+- Downloads verify against manifest digests.
+- Sub-agents never appear in the RFC skill feed.
+
+### Phase 5: CLI Support
+
+Extend `skillserver` CLI to work with sub-agents.
+
+Deliverables:
+
+- `skillserver validate subagent <path>` or equivalent lint command.
+- `skillserver publish-subagent <path>` command.
+- `publish-all` support for mixed skill/sub-agent source trees or a separate sub-agent mode.
+- Helpful diagnostics for invalid frontmatter.
+
+Acceptance criteria:
+
+- CLI validates the same fields as the server.
+- CLI can publish a single `.md` sub-agent definition.
+- CLI can avoid duplicate uploads unless forced.
+- CLI docs include sub-agent examples.
+
+### Phase 6: Client And NetClaw Sync Integration
+
+Teach clients to consume the native manifest.
+
+Deliverables:
+
+- `Netclaw.SkillClient` methods for native manifest traversal.
+- Sub-agent upload/download client methods.
+- NetClaw daemon sync support for native manifest sub-agent resources.
+- Local sync state for sub-agents.
+- Safe install path for server-synced sub-agent files.
+
+Acceptance criteria:
+
+- NetClaw can sync sub-agents from SkillServer without overwriting user-authored files.
+- NetClaw can resolve skill `metadata.subagent` targets after sync.
+- Failed sync keeps existing local sub-agents.
+- Removed server-side sub-agents are pruned only after a confirmed successful feed sync.
+
+### Phase 7: Hardening, Docs, And Release Readiness
+
+Make the feature safe enough to ship.
+
+Deliverables:
+
+- Security review for archive extraction and markdown prompt distribution.
+- Integration tests across server, CLI, and client.
+- Migration notes for existing resourceful skill feeds.
+- Updated README and CLI documentation.
+- Release notes.
+
+Acceptance criteria:
+
+- `dotnet build -c Release` succeeds.
+- `dotnet test -c Release` passes.
+- Header verification passes.
+- Slopwatch passes with no new violations.
+- Docs clearly separate RFC compatibility from native manifest behavior.
+
+## GitHub Issues
+
+### Issue 1: Define native manifest and sub-agent sync specifications
+
+Labels: `documentation`, `spec`, `epic`
+
+Body:
+
+```markdown
+Create the public design specs for SkillServer native sync.
+
+Tasks:
+- [ ] Define AgentSkills.io-compatible skill package rules.
+- [ ] Define NetClaw sub-agent package rules.
+- [ ] Define `/manifest.json` native feed structure.
+- [ ] Document `metadata.subagent` as a route, not a dependency.
+- [ ] Link specs from README.
+
+Acceptance criteria:
+- Specs are committed under `docs/specs/`.
+- README links to the specs.
+- Current implementation gaps are called out explicitly.
+```
+
+### Issue 2: Align skill artifact distribution with the Cloudflare RFC
+
+Labels: `server`, `rfc-compatibility`
+
+Body:
+
+```markdown
+Add archive artifact support for skills with resources while preserving existing per-file resource routes.
+
+Tasks:
+- [ ] Generate deterministic archives for resourceful skill versions.
+- [ ] Add archive download endpoint.
+- [ ] Emit `type: "archive"` in the RFC feed for resourceful skills.
+- [ ] Keep `type: "skill-md"` for single-file skills.
+- [ ] Preserve existing resource URLs for compatibility.
+
+Acceptance criteria:
+- RFC feed artifact digests verify the exact bytes at `url`.
+- Archive entries contain `SKILL.md` at the archive root.
+- Path traversal and absolute paths are rejected.
+- Integration tests cover `skill-md` and `archive` entries.
+```
+
+### Issue 3: Implement `/manifest.json` native manifest root and skill collection
+
+Labels: `server`, `manifest`
+
+Body:
+
+```markdown
+Implement the initial native manifest tree for skills.
+
+Tasks:
+- [ ] Add `/manifest.json` root endpoint.
+- [ ] Add `/manifest/skills/index.json`.
+- [ ] Add path-based skills pages.
+- [ ] Add skill identity index endpoints.
+- [ ] Add skill version detail endpoints.
+- [ ] Add source-generated JSON models.
+
+Acceptance criteria:
+- Clients can traverse from `/manifest.json` to a skill version detail by following `href` values.
+- Skill version detail reuses the RFC artifact fields and values.
+- Unsupported future collections can be ignored by clients.
+```
+
+### Issue 4: Add sub-agent storage and artifact endpoints
+
+Labels: `server`, `subagents`
+
+Body:
+
+```markdown
+Add first-class SkillServer support for versioned NetClaw sub-agent definitions.
+
+Tasks:
+- [ ] Add sub-agent tables and migrations.
+- [ ] Add sub-agent domain/API models.
+- [ ] Add parser/validator for NetClaw sub-agent markdown.
+- [ ] Add upload endpoint.
+- [ ] Add metadata endpoints.
+- [ ] Add `agent.md` artifact download endpoint.
+- [ ] Add delete/version management behavior consistent with skills.
+
+Acceptance criteria:
+- Valid sub-agent markdown uploads successfully.
+- Invalid frontmatter returns actionable errors.
+- Duplicate versions return conflict.
+- Artifact digest verifies downloaded `agent.md` bytes.
+```
+
+### Issue 5: Add sub-agent collection to the native manifest
+
+Labels: `server`, `manifest`, `subagents`
+
+Body:
+
+```markdown
+Expose sub-agents through the native manifest without adding them to the RFC skill feed.
+
+Tasks:
+- [ ] Add `/manifest/subagents/index.json`.
+- [ ] Add path-based sub-agent pages.
+- [ ] Add sub-agent identity index endpoints.
+- [ ] Add sub-agent version detail endpoints.
+- [ ] Link sub-agent collection from `/manifest.json`.
+- [ ] Link skill version `routesToSubagent` when `metadata.subagent` is present.
+
+Acceptance criteria:
+- Native clients can traverse from root to sub-agent version detail.
+- Sub-agent details use `kind: "subagent-version"` and `type: "agent-md"`.
+- RFC index output remains skill-only.
+```
+
+### Issue 6: Extend `Netclaw.SkillClient` for native manifest and sub-agents
+
+Labels: `client`, `manifest`, `subagents`
+
+Body:
+
+```markdown
+Add typed client support for native manifest traversal and sub-agent artifact operations.
+
+Tasks:
+- [ ] Add native manifest models.
+- [ ] Add `GetManifestAsync`.
+- [ ] Add skill manifest traversal helpers.
+- [ ] Add sub-agent manifest traversal helpers.
+- [ ] Add upload/download methods for sub-agent definitions.
+- [ ] Preserve AOT source-generated serialization.
+
+Acceptance criteria:
+- Client can fetch root manifest and follow collection links.
+- Client can download a sub-agent artifact and verify digest.
+- Existing RFC client methods remain unchanged.
+```
+
+### Issue 7: Extend CLI validation and publishing for sub-agents
+
+Labels: `cli`, `subagents`
+
+Body:
+
+```markdown
+Teach `skillserver` CLI how to validate and publish NetClaw sub-agent definitions.
+
+Tasks:
+- [ ] Add sub-agent validation command or extend lint command.
+- [ ] Add publish command for a single sub-agent `.md` file.
+- [ ] Add duplicate handling and force behavior.
+- [ ] Add dry-run and verbose output.
+- [ ] Update CLI README.
+
+Acceptance criteria:
+- CLI validates required and optional fields consistently with the server.
+- CLI publishes valid sub-agent definitions.
+- CLI reports actionable errors for invalid files.
+```
+
+### Issue 8: Add native manifest sync support in NetClaw
+
+Labels: `netclaw-integration`, `subagents`, `manifest`
+
+Body:
+
+```markdown
+Update NetClaw to sync SkillServer native manifest resources, including sub-agent definitions.
+
+Tasks:
+- [ ] Fetch `/manifest.json` for SkillServer feeds that support it.
+- [ ] Fall back to RFC skill sync when native manifest is unavailable.
+- [ ] Sync skill artifacts using native manifest skill details.
+- [ ] Sync sub-agent `agent-md` artifacts into a managed server-feed location.
+- [ ] Track sub-agent sync state by feed, name, version, and digest.
+- [ ] Preserve user-authored local sub-agent files.
+- [ ] Ensure skill `metadata.subagent` targets resolve after sync.
+
+Acceptance criteria:
+- NetClaw syncs sub-agents without overwriting user-authored definitions.
+- Failed sync keeps existing local definitions.
+- Removed remote definitions are pruned only after a confirmed successful sync.
+```
+
+### Issue 9: Harden security and compatibility for native sync
+
+Labels: `security`, `testing`, `compatibility`
+
+Body:
+
+```markdown
+Add end-to-end safety checks for native manifest sync and sub-agent artifacts.
+
+Tasks:
+- [ ] Threat-model archive downloads and sub-agent prompt distribution.
+- [ ] Test digest mismatch rejection.
+- [ ] Test path traversal rejection.
+- [ ] Test auth behavior for manifest and artifact endpoints.
+- [ ] Test unsupported resource kinds are ignored by clients.
+- [ ] Document migration behavior for existing resourceful skills.
+
+Acceptance criteria:
+- Security-sensitive failure modes are covered by tests.
+- Documentation states trust assumptions and sync safety behavior.
+- Existing RFC feed consumers remain compatible.
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,11 @@
+# SkillServer Specifications
+
+These specifications describe the public formats SkillServer publishes and consumes.
+
+Some documents are target designs for upcoming work. Each spec calls out current implementation gaps where relevant.
+
+| Spec | Purpose |
+|------|---------|
+| [Skill Packages](skills.md) | AgentSkills.io-compatible skill authoring and SkillServer artifact projection. |
+| [Sub-Agent Packages](subagents.md) | NetClaw sub-agent definition format and proposed SkillServer publication model. |
+| [Native Manifest](native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future artifact types. |

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -200,6 +200,19 @@ Native clients should:
 
 Clients must ignore unsupported resource kinds and unknown fields.
 
+## Client-Controlled Destinations
+
+The native manifest describes what artifacts exist and where to download them. It does not prescribe where a client must install them.
+
+Each client owns its local sync policy:
+
+- NetClaw may install server-synced skills and sub-agents under managed directories inside its configured home directory.
+- A non-NetClaw client may sync the same artifacts into its own skills, commands, agents, plugins, or cache directories.
+- A client may expose configuration for per-feed destination roots, per-resource-kind destination roots, or both.
+- A client must keep enough local state to avoid overwriting user-authored files and to prune only artifacts it previously synced from that feed.
+
+Manifest `url`, `digest`, `name`, `version`, `kind`, and `type` fields are portable. Local filesystem layout is intentionally out of scope for the server protocol.
+
 ## Authentication
 
 Read access may be open for public registries. Private registries may require the same bearer API key already used by SkillServer write endpoints and NetClaw feed configuration.

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -213,6 +213,45 @@ Each client owns its local sync policy:
 
 Manifest `url`, `digest`, `name`, `version`, `kind`, and `type` fields are portable. Local filesystem layout is intentionally out of scope for the server protocol.
 
+## Non-NetClaw Client Sync
+
+Non-NetClaw clients should consume the native manifest through an adapter layer rather than requiring SkillServer to publish client-specific feeds.
+
+The recommended split is:
+
+- SkillServer publishes canonical, verified artifacts.
+- `Netclaw.SkillClient` fetches manifests and artifact bytes without choosing local paths.
+- A client-specific adapter maps each supported artifact into that client's local format and destination.
+
+For sub-agents, an adapter should implement this flow:
+
+1. Follow the `subagents` collection from `/manifest.json`.
+2. Traverse to each `subagent-version` detail.
+3. Download the `agent-md` artifact from `url`.
+4. Verify the artifact bytes against `digest`.
+5. Parse the markdown frontmatter and body.
+6. Convert the definition to the target client's local agent format.
+7. Write only into the adapter's configured managed sync location.
+8. Record source feed, name, version, digest, and generated local file path for pruning and updates.
+
+If the target client can consume NetClaw-style markdown directly, the adapter can install `agent-md` without conversion. If the target client has a different format, the adapter owns the mapping.
+
+Minimum portable fields for adapters are:
+
+| Source Field | Adapter Use |
+|--------------|-------------|
+| `name` | Local agent identity or filename. |
+| `description` | Discovery text shown by the target client. |
+| Markdown body | System prompt or agent instructions. |
+| `tools` | Advisory capability metadata when the target client supports it. |
+| `modelRole` | Optional model/profile hint when the target client supports it. |
+| `timeoutSeconds` | Optional execution timeout when the target client supports it. |
+| `visibility` | Whether the adapter exposes or hides the agent when the target client supports visibility. |
+
+Adapters must ignore unsupported fields rather than rejecting otherwise valid artifacts. A target client that needs additional metadata should use namespaced extension fields and document how its adapter interprets them.
+
+The server protocol should remain one manifest with portable artifact types. It should not grow separate `/manifest/opencode`, `/manifest/claude-code`, or similar feeds unless a client has a hard incompatibility that cannot be solved by an adapter.
+
 ## Authentication
 
 Read access may be open for public registries. Private registries may require the same bearer API key already used by SkillServer write endpoints and NetClaw feed configuration.

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -220,8 +220,11 @@ Non-NetClaw clients should consume the native manifest through an adapter layer 
 The recommended split is:
 
 - SkillServer publishes canonical, verified artifacts.
-- `Netclaw.SkillClient` fetches manifests and artifact bytes without choosing local paths.
+- `Netclaw.SkillClient` fetches manifests and artifact bytes without choosing local paths or target client formats.
+- CLI sync commands provide unopinionated download/update primitives for supported resource kinds.
 - A client-specific adapter maps each supported artifact into that client's local format and destination.
+
+This is the same contract SkillServer should use for skills and sub-agents: sync tooling can fetch, verify, compare, and stage artifacts, but the consuming client decides how those artifacts become local runtime configuration.
 
 For sub-agents, an adapter should implement this flow:
 
@@ -251,6 +254,8 @@ Minimum portable fields for adapters are:
 Adapters must ignore unsupported fields rather than rejecting otherwise valid artifacts. A target client that needs additional metadata should use namespaced extension fields and document how its adapter interprets them.
 
 The server protocol should remain one manifest with portable artifact types. It should not grow separate `/manifest/opencode`, `/manifest/claude-code`, or similar feeds unless a client has a hard incompatibility that cannot be solved by an adapter.
+
+The first-party CLI and library should make OpenCode, Claude Code, and other future consumers supportable by composition rather than hard-coding their paths into the server protocol. A future OpenCode sync command, for example, should be able to use the same manifest traversal and verified artifact download helpers, then apply an OpenCode-specific destination and format adapter.
 
 ## Authentication
 

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -1,0 +1,221 @@
+# Native Manifest Specification
+
+Status: target design. `/manifest.json` is documented in README today but is not implemented in the current server route map.
+
+The native manifest is SkillServer's richer, non-RFC sync feed. It must not replace the Cloudflare Agent Skills Discovery RFC feed. Instead, it provides a linked catalog for SkillServer-aware clients that need pagination, version history, sub-agent definitions, and additional metadata.
+
+## Goals
+
+- Keep `/.well-known/agent-skills/index.json` as the standards-compatible skill discovery projection.
+- Add `/manifest.json` as a native entry point for SkillServer-aware clients.
+- Use HATEOAS-style links with path-based pagination.
+- Reuse the RFC skill artifact shape for every skill version.
+- Publish sub-agents as first-class native resources, outside the RFC skill feed.
+- Let clients follow links instead of constructing pagination URLs.
+
+## Non-Goals
+
+- Do not list sub-agents in the Cloudflare RFC skill feed.
+- Do not create a separate skill install format for native clients.
+- Do not define a general transitive dependency resolver in the first version.
+- Do not require clients to understand query-string cursors.
+
+## Endpoint Shape
+
+The stable entry point is:
+
+```text
+GET /manifest.json
+```
+
+The manifest tree uses path prefixes for collection and page navigation:
+
+```text
+/manifest.json
+/manifest/skills/index.json
+/manifest/skills/pages/a-f.json
+/manifest/skills/{skillName}/index.json
+/manifest/skills/{skillName}/versions/{version}.json
+/manifest/subagents/index.json
+/manifest/subagents/pages/a-f.json
+/manifest/subagents/{subagentName}/index.json
+/manifest/subagents/{subagentName}/versions/{version}.json
+```
+
+Clients must follow returned `href` values. The path structure is readable and stable, but the server owns pagination boundaries.
+
+## Root Manifest
+
+`/manifest.json` links to the native collections exposed by the registry.
+
+```json
+{
+  "$schema": "https://schemas.netclaw.dev/skillserver/manifest/0.1.0",
+  "generatedAt": "2026-06-29T12:00:00Z",
+  "links": {
+    "self": { "href": "/manifest.json" },
+    "rfcSkills": { "href": "/.well-known/agent-skills/index.json" },
+    "skills": { "href": "/manifest/skills/index.json" },
+    "subagents": { "href": "/manifest/subagents/index.json" }
+  }
+}
+```
+
+Clients that do not understand a linked collection should ignore it.
+
+## Collection Index
+
+A collection index links to one or more server-defined pages.
+
+```json
+{
+  "kind": "skill-index",
+  "links": {
+    "self": { "href": "/manifest/skills/index.json" }
+  },
+  "pages": [
+    {
+      "range": "a-f",
+      "href": "/manifest/skills/pages/a-f.json"
+    },
+    {
+      "range": "g-m",
+      "href": "/manifest/skills/pages/g-m.json"
+    }
+  ]
+}
+```
+
+The `range` value is informational. Clients should not assume it is alphabetical or stable across registries.
+
+## Collection Page
+
+A collection page lists identities and coarse version bounds.
+
+```json
+{
+  "kind": "skill-page",
+  "range": "a-f",
+  "items": [
+    {
+      "name": "support-triage",
+      "latestVersion": "1.2.0",
+      "versionRange": {
+        "min": "1.0.0",
+        "max": "1.2.0",
+        "count": 4
+      },
+      "href": "/manifest/skills/support-triage/index.json"
+    }
+  ],
+  "links": {
+    "self": { "href": "/manifest/skills/pages/a-f.json" }
+  }
+}
+```
+
+If a page grows too large, the server may replace it with links to smaller child pages in a future schema version.
+
+## Identity Index
+
+An identity index lists all versions for one skill or sub-agent.
+
+```json
+{
+  "kind": "skill",
+  "name": "support-triage",
+  "latestVersion": "1.2.0",
+  "versions": [
+    {
+      "version": "1.2.0",
+      "publishedAt": "2026-06-29T12:00:00Z",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "href": "/manifest/skills/support-triage/versions/1.2.0.json"
+    }
+  ],
+  "links": {
+    "self": { "href": "/manifest/skills/support-triage/index.json" }
+  }
+}
+```
+
+## Skill Version Detail
+
+Skill version details wrap the exact artifact object that the RFC feed exposes for the same skill version.
+
+```json
+{
+  "kind": "skill-version",
+  "artifact": {
+    "name": "support-triage",
+    "version": "1.2.0",
+    "type": "archive",
+    "description": "Triage support tickets and produce a concise diagnostic plan.",
+    "url": "/skills/support-triage/1.2.0/archive.zip",
+    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "routesToSubagent": {
+    "name": "technical-support-diagnostician",
+    "href": "/manifest/subagents/technical-support-diagnostician/index.json"
+  },
+  "links": {
+    "self": { "href": "/manifest/skills/support-triage/versions/1.2.0.json" }
+  }
+}
+```
+
+The `routesToSubagent` value is derived from `metadata.subagent` in `SKILL.md`. It is a runtime route hint, not a package dependency.
+
+## Sub-Agent Version Detail
+
+Sub-agent version details use the same content-addressed artifact semantics, but are native-only resources.
+
+```json
+{
+  "kind": "subagent-version",
+  "name": "technical-support-diagnostician",
+  "version": "1.0.0",
+  "type": "agent-md",
+  "description": "Diagnose incomplete technical support tickets and identify missing evidence.",
+  "url": "/subagents/technical-support-diagnostician/1.0.0/agent.md",
+  "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "links": {
+    "self": { "href": "/manifest/subagents/technical-support-diagnostician/versions/1.0.0.json" }
+  }
+}
+```
+
+## Sync Semantics
+
+Native clients should:
+
+1. Fetch `/manifest.json`.
+2. Follow collection links for supported resource kinds.
+3. Follow page links to identity indexes.
+4. Compare version and digest with local sync state.
+5. Download changed artifacts from `url`.
+6. Verify `digest` before installing any artifact.
+7. Keep existing local artifacts when a network request fails.
+8. Prune server-synced artifacts only after a successful collection sync confirms removal.
+
+Clients must ignore unsupported resource kinds and unknown fields.
+
+## Authentication
+
+Read access may be open for public registries. Private registries may require the same bearer API key already used by SkillServer write endpoints and NetClaw feed configuration.
+
+Clients should send configured credentials to both manifest and artifact URLs for the same feed origin.
+
+## Compatibility With The RFC Feed
+
+The RFC feed remains the compatibility contract for generic AgentSkills.io clients.
+
+The native manifest must not change the meaning of RFC fields:
+
+- `name` identifies the same skill.
+- `description` has the same activation meaning.
+- `type` has the same artifact distribution meaning.
+- `url` points to the same bytes for a version.
+- `digest` verifies the same bytes at `url`.
+
+For sub-agents, native resources should mimic those artifact semantics without pretending to be RFC skills.

--- a/docs/specs/skills.md
+++ b/docs/specs/skills.md
@@ -1,0 +1,170 @@
+# Skill Package Specification
+
+Status: active for skill authoring, partial implementation for artifact distribution alignment.
+
+This document defines how SkillServer treats skills. The authoring format remains compatible with AgentSkills.io. SkillServer-specific behavior must live in explicit extension fields or native manifest metadata, not in a competing skill format.
+
+## Goals
+
+- Keep `SKILL.md` compatible with AgentSkills.io.
+- Keep `/.well-known/agent-skills/index.json` compatible with the Cloudflare Agent Skills Discovery RFC.
+- Reuse the RFC skill artifact shape inside the richer native manifest.
+- Preserve the existing NetClaw `metadata.subagent` routing convention.
+- Avoid defining a package-manager dependency graph for skills and sub-agents in the first version.
+
+## Directory Layout
+
+A directory-based skill contains a required `SKILL.md` file and optional supporting resources:
+
+```text
+my-skill/
+  SKILL.md
+  references/
+    guide.md
+  scripts/
+    helper.sh
+  assets/
+    template.json
+```
+
+The required `SKILL.md` file has YAML frontmatter followed by Markdown instructions.
+
+## Frontmatter
+
+SkillServer accepts the AgentSkills.io fields below.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `name` | Yes | Lowercase kebab-case skill identity. Must match the parent directory for strict validation. |
+| `description` | Yes | Short activation description. Maximum 1024 characters. |
+| `license` | No | License name or bundled license reference. |
+| `compatibility` | No | Runtime or client compatibility notes. |
+| `allowed-tools` | No | Experimental AgentSkills.io advisory field. |
+| `metadata` | No | Extension point for string or scalar values. |
+
+SkillServer and NetClaw currently use these metadata conventions:
+
+| Metadata Key | Status | Meaning |
+|--------------|--------|---------|
+| `version` | Implemented in NetClaw scanning | Optional local version hint. SkillServer upload currently receives version out of band. |
+| `subagent` | Implemented in NetClaw | Route this skill through a named user-facing sub-agent. |
+
+Example:
+
+```yaml
+---
+name: support-triage
+description: Triage support tickets and produce a concise diagnostic plan.
+metadata:
+  version: "1.0.0"
+  subagent: technical-support-diagnostician
+---
+```
+
+## Sub-Agent Routing
+
+`metadata.subagent` is a NetClaw execution route, not a package dependency declaration.
+
+When a skill declares `metadata.subagent`:
+
+- The value must be a non-empty lowercase kebab-case sub-agent name.
+- The target sub-agent must be registered and `user-facing` at runtime.
+- NetClaw routes slash-command and `skill_load` activation through that sub-agent.
+- The skill body is appended to the sub-agent system prompt as a `Skill Overlay`.
+- The sub-agent's runtime tools are still inherited from the parent session policy.
+
+This keeps the relationship simple:
+
+```text
+skill activation -> routed through one sub-agent
+```
+
+It does not mean:
+
+```text
+skill package -> installs sub-agent package as a transitive dependency
+```
+
+## RFC Artifact Shape
+
+Every published skill version should have a canonical artifact object matching the Cloudflare RFC fields plus SkillServer's version extension:
+
+```json
+{
+  "name": "support-triage",
+  "version": "1.0.0",
+  "type": "skill-md",
+  "description": "Triage support tickets and produce a concise diagnostic plan.",
+  "url": "/skills/support-triage/1.0.0/SKILL.md",
+  "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+```
+
+Field meanings:
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Skill identity from `SKILL.md`. |
+| `version` | SkillServer version for this artifact. |
+| `type` | `skill-md` for a single `SKILL.md` artifact or `archive` for a packaged skill directory. |
+| `description` | Same activation description as `SKILL.md`. |
+| `url` | Artifact download URL. |
+| `digest` | SHA-256 digest of the exact artifact bytes at `url`, formatted as `sha256:{hex}`. |
+
+The native manifest must reuse this object instead of inventing another skill install contract.
+
+## Resource Distribution
+
+Target behavior:
+
+- Skills with only `SKILL.md` should publish as `type: "skill-md"`.
+- Skills with supporting files should publish as `type: "archive"`.
+- Archive artifacts should contain `SKILL.md` at the archive root plus supporting files under their relative paths.
+- The RFC feed and native manifest should point to the same artifact URL and digest for a given skill version.
+
+Current implementation gap:
+
+- SkillServer currently stores resource files individually and exposes them through a `resources` extension in the RFC-shaped index.
+- SkillServer has an `archive` type constant but does not currently build or serve skill archives.
+
+The migration path is to add archive artifact support while preserving existing per-file resource routes for compatibility.
+
+## Validation Requirements
+
+Skill validation should reject:
+
+- Missing or invalid YAML frontmatter.
+- Missing `name` or `description`.
+- Names that do not meet AgentSkills.io naming rules.
+- Directory/name mismatches in strict mode.
+- Resource paths with path traversal or absolute paths.
+- Invalid `metadata.subagent` values when present.
+
+Validation should warn, not fail, for unknown metadata keys.
+
+## Native Manifest Projection
+
+The native manifest version detail should wrap the same RFC artifact object and add SkillServer metadata around it:
+
+```json
+{
+  "kind": "skill-version",
+  "artifact": {
+    "name": "support-triage",
+    "version": "1.0.0",
+    "type": "skill-md",
+    "description": "Triage support tickets and produce a concise diagnostic plan.",
+    "url": "/skills/support-triage/1.0.0/SKILL.md",
+    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "routesToSubagent": {
+    "name": "technical-support-diagnostician",
+    "href": "/manifest/subagents/technical-support-diagnostician/index.json"
+  },
+  "links": {
+    "self": "/manifest/skills/support-triage/versions/1.0.0.json"
+  }
+}
+```
+
+The manifest may expose parsed `metadata.subagent` as `routesToSubagent`, but the source of truth remains the skill frontmatter.

--- a/docs/specs/subagents.md
+++ b/docs/specs/subagents.md
@@ -162,3 +162,30 @@ The exact local path is a NetClaw implementation detail, not a SkillServer proto
 - Sync state records version, digest, and source feed.
 
 Non-NetClaw clients can use the same server artifacts by configuring their own sync destination. They should preserve equivalent ownership boundaries between user-authored files and server-synced files.
+
+## Client Adapters
+
+Non-NetClaw clients should sync sub-agents through an adapter that understands that client's local agent format.
+
+The canonical SkillServer artifact is `agent-md`: YAML frontmatter plus a markdown system prompt body. An adapter may either install this file directly or translate it into the target client's native format.
+
+Adapter responsibilities:
+
+- Decide whether the target client supports `agent-md` directly or needs conversion.
+- Map `name`, `description`, and body text to the target client's required fields.
+- Preserve advisory fields such as `tools`, `modelRole`, `timeoutSeconds`, and `visibility` when supported.
+- Ignore unsupported advisory fields.
+- Write generated files only into a configured managed destination for that target client.
+- Track source feed, name, version, digest, and generated file path so updates and pruning do not touch user-authored files.
+- Surface warnings when a target client cannot represent an important field.
+
+Example adapter outcomes:
+
+| Target Client Capability | Adapter Behavior |
+|--------------------------|------------------|
+| Accepts markdown agent files with frontmatter | Write `agent-md` directly. |
+| Accepts markdown prompts but different frontmatter | Rewrite frontmatter and preserve the body. |
+| Accepts JSON/YAML agent definitions | Convert frontmatter and body into the client's schema. |
+| Does not support sub-agents | Ignore `subagent-version` resources and report unsupported capability if requested. |
+
+This keeps SkillServer portable: it publishes one sub-agent artifact model, while clients own installation and format translation.

--- a/docs/specs/subagents.md
+++ b/docs/specs/subagents.md
@@ -169,6 +169,8 @@ Non-NetClaw clients should sync sub-agents through an adapter that understands t
 
 The canonical SkillServer artifact is `agent-md`: YAML frontmatter plus a markdown system prompt body. An adapter may either install this file directly or translate it into the target client's native format.
 
+Sub-agent sync should follow the same unopinionated model as skill sync. Shared tooling should fetch and verify artifacts, compare local state, and hand the result to a destination adapter. It should not assume NetClaw's `~/.netclaw/agents` layout, OpenCode's layout, Claude Code's layout, or any other target layout.
+
 Adapter responsibilities:
 
 - Decide whether the target client supports `agent-md` directly or needs conversion.

--- a/docs/specs/subagents.md
+++ b/docs/specs/subagents.md
@@ -148,13 +148,17 @@ Sub-agent validation should reject:
 
 Validation should warn, not fail, for unknown fields.
 
-## Install Location
+## Client Install Location
+
+SkillServer does not define where sub-agent artifacts are installed after download. It publishes versioned `agent-md` artifacts and native manifest metadata; each client maps those artifacts into its own local configuration model.
 
 NetClaw sync should install downloaded sub-agent definitions into a managed server-feed subdirectory under the NetClaw agents area rather than overwriting user-authored files directly.
 
-The exact local path is a NetClaw implementation detail, but it should preserve these properties:
+The exact local path is a NetClaw implementation detail, not a SkillServer protocol requirement. NetClaw's layout should preserve these properties:
 
 - User-authored `~/.netclaw/agents/*.md` files remain editable.
 - Server-synced files are removable when the feed no longer advertises them.
 - Duplicate names resolve deterministically with loud diagnostics.
 - Sync state records version, digest, and source feed.
+
+Non-NetClaw clients can use the same server artifacts by configuring their own sync destination. They should preserve equivalent ownership boundaries between user-authored files and server-synced files.

--- a/docs/specs/subagents.md
+++ b/docs/specs/subagents.md
@@ -1,0 +1,160 @@
+# Sub-Agent Package Specification
+
+Status: current NetClaw file format, target SkillServer publication model.
+
+This document defines the sub-agent definition format SkillServer should publish and the NetClaw runtime already understands. Sub-agents are not AgentSkills.io skills and must not be listed in the Cloudflare RFC skill feed.
+
+## Goals
+
+- Preserve the existing NetClaw sub-agent markdown format.
+- Publish sub-agents as first-class native manifest resources.
+- Keep sub-agent sync separate from skill artifact sync.
+- Avoid a general dependency graph in the first version.
+- Allow skills to route to sub-agents through existing `metadata.subagent` frontmatter.
+
+## Local File Layout
+
+NetClaw currently loads sub-agent definitions from one markdown file per agent:
+
+```text
+~/.netclaw/agents/
+  technical-support-diagnostician.md
+  code-analyst.md
+  summarizer.md
+```
+
+The file has YAML frontmatter followed by a markdown system prompt body.
+
+```markdown
+---
+name: technical-support-diagnostician
+description: Diagnose incomplete technical support tickets and identify missing evidence.
+modelRole: Compaction
+timeoutSeconds: 120
+visibility: user-facing
+emitStructuredFindings: false
+---
+
+You are a technical support diagnostician.
+
+Identify the most likely root cause, missing evidence, and next diagnostic step.
+Return concise findings for the parent session.
+```
+
+The filename is for humans. The authoritative identity is `name` in frontmatter.
+
+## Frontmatter
+
+Current NetClaw-supported fields:
+
+| Field | Required | Default | Meaning |
+|-------|----------|---------|---------|
+| `name` | Yes | None | Unique lowercase kebab-case name used by `spawn_agent`. |
+| `description` | Yes | None | One-line description shown in the available sub-agents context layer. |
+| `tools` | No | `[]` | Advisory tool metadata only. Does not grant or restrict runtime tools. |
+| `modelRole` | No | `Compaction` | `Compaction` or `Main`. |
+| `timeoutSeconds` | No | `60` | Inactivity timeout in seconds. Valid range: 5 to 600. |
+| `prefillTimeoutSeconds` | No | Runtime default | Wait-for-first-delta timeout in seconds. Valid range: 5 to 3600. |
+| `visibility` | No | `user-facing` | `user-facing` or `internal`. PascalCase values are also accepted. |
+| `emitStructuredFindings` | No | `false` | Whether successful output becomes parent-reviewed memory findings. |
+
+Unknown fields are ignored by the current NetClaw loader. SkillServer publication may read additional metadata without affecting NetClaw runtime behavior.
+
+## Versioning
+
+NetClaw local runtime does not require a sub-agent version today.
+
+SkillServer publication does require a version for sync, caching, and rollback. The initial publication flow should accept a version out of band through the CLI, matching skill upload behavior. A future CLI may also accept a compatible frontmatter extension such as:
+
+```yaml
+metadata:
+  version: "1.0.0"
+```
+
+Until NetClaw runtime needs local version awareness, version metadata should remain a SkillServer packaging concern.
+
+## Runtime Semantics
+
+Sub-agents are specialist workers spawned by a parent NetClaw session.
+
+- The sub-agent system prompt is the markdown body after frontmatter.
+- The first user message is the task supplied to `spawn_agent`.
+- Optional runtime context is prefixed to that task, not written into the system prompt.
+- Runtime tools are inherited from the parent session audience/profile policy.
+- The sub-agent denylist prevents recursive `spawn_agent` calls.
+- `tools` frontmatter is only advisory metadata.
+- `user-facing` sub-agents are advertised to the frontline model.
+- `internal` sub-agents are hidden from normal `spawn_agent` discovery.
+
+## Relationship To Skills
+
+A skill may route execution through one sub-agent by declaring `metadata.subagent` in `SKILL.md` frontmatter.
+
+```yaml
+---
+name: support-triage
+description: Triage support tickets and produce a concise diagnostic plan.
+metadata:
+  subagent: technical-support-diagnostician
+---
+```
+
+When routed, the skill body is appended to the sub-agent prompt as a `Skill Overlay` during activation.
+
+This is intentionally not a package dependency graph. The sync system should ensure referenced sub-agents can be installed, but runtime activation remains the source of truth for how a skill and sub-agent compose.
+
+Sub-agents should not declare required skills in the first version. If a sub-agent needs a skill's instructions, encode that operational guidance in the sub-agent prompt or use a future NetClaw runtime field after there is a concrete loading requirement.
+
+## SkillServer Artifact Shape
+
+The native manifest should expose sub-agent versions with the same artifact semantics used for skills, but with sub-agent-specific `kind` and `type` values:
+
+```json
+{
+  "kind": "subagent-version",
+  "name": "technical-support-diagnostician",
+  "version": "1.0.0",
+  "type": "agent-md",
+  "description": "Diagnose incomplete technical support tickets and identify missing evidence.",
+  "url": "/subagents/technical-support-diagnostician/1.0.0/agent.md",
+  "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+```
+
+Field meanings:
+
+| Field | Meaning |
+|-------|---------|
+| `kind` | Native manifest resource kind. Must be `subagent-version` for version details. |
+| `name` | Sub-agent identity from frontmatter. |
+| `version` | SkillServer publication version. |
+| `type` | `agent-md` for a single markdown sub-agent definition. |
+| `description` | Same description as frontmatter. |
+| `url` | Artifact download URL. |
+| `digest` | SHA-256 digest of the exact artifact bytes at `url`. |
+
+Initial sub-agent sync should only support `agent-md`. Archive-based sub-agent packages can be added later if there is a real need for bundled resources.
+
+## Validation Requirements
+
+Sub-agent validation should reject:
+
+- Missing or invalid YAML frontmatter.
+- Missing `name` or `description`.
+- Empty system prompt body.
+- Invalid name format.
+- Duplicate names within the same upload set or registry scope.
+- Invalid `modelRole`, `visibility`, `timeoutSeconds`, or `prefillTimeoutSeconds` values.
+
+Validation should warn, not fail, for unknown fields.
+
+## Install Location
+
+NetClaw sync should install downloaded sub-agent definitions into a managed server-feed subdirectory under the NetClaw agents area rather than overwriting user-authored files directly.
+
+The exact local path is a NetClaw implementation detail, but it should preserve these properties:
+
+- User-authored `~/.netclaw/agents/*.md` files remain editable.
+- Server-synced files are removable when the feed no longer advertises them.
+- Duplicate names resolve deterministically with loud diagnostics.
+- Sync state records version, digest, and source feed.


### PR DESCRIPTION
## Summary
- add SkillServer specs for skills, sub-agents, and native manifest sync
- document the native manifest and sub-agent sync epic with GitHub tracking links
- update README and project context to distinguish implemented RFC discovery from planned native manifest support

## Verification
- git diff --check

## Tracking
- Epic: #84
- Sub-issues: #85, #86, #87, #88, #89, #90, #91, #92, #93