### PR TITLE
Add skill archive artifacts

### DIFF
--- a/docs/epics/subagent-sync.md
+++ b/docs/epics/subagent-sync.md
@@ -72,9 +72,10 @@ Bring SkillServer's skill artifact model closer to the Cloudflare RFC.
 Deliverables:
 
 - Archive artifact generation for skills with resources.
-- Archive download endpoint for versioned skills.
+- `.zip` archive download endpoint for versioned skills at `/skills/{name}/{version}/archive.zip`.
 - RFC index emits `type: "archive"` for resourceful skills.
 - Existing per-file resource routes remain available for compatibility.
+- Additive archive artifact metadata that preserves existing `SKILL.md` digest behavior.
 
 Acceptance criteria:
 
@@ -82,6 +83,7 @@ Acceptance criteria:
 - `archive` entries digest the raw archive bytes.
 - Archives contain `SKILL.md` at the root.
 - Archive paths reject traversal and absolute paths.
+- Existing `SKILL.md` download and digest verification behavior remains compatible.
 - Existing resource tests keep passing or have explicit compatibility replacements.
 
 ### Phase 3: Native Manifest API
@@ -220,15 +222,17 @@ Add archive artifact support for skills with resources while preserving existing
 
 Tasks:
 - [ ] Generate deterministic archives for resourceful skill versions.
-- [ ] Add archive download endpoint.
+- [ ] Add `.zip` archive download endpoint at `/skills/{name}/{version}/archive.zip`.
 - [ ] Emit `type: "archive"` in the RFC feed for resourceful skills.
 - [ ] Keep `type: "skill-md"` for single-file skills.
 - [ ] Preserve existing resource URLs for compatibility.
+- [ ] Preserve existing `SKILL.md` digest behavior by storing archive artifact metadata additively.
 
 Acceptance criteria:
 - RFC feed artifact digests verify the exact bytes at `url`.
 - Archive entries contain `SKILL.md` at the archive root.
 - Path traversal and absolute paths are rejected.
+- Existing `SKILL.md` download and digest verification APIs remain compatible.
 - Integration tests cover `skill-md` and `archive` entries.
 ```
 

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -142,6 +142,7 @@ An identity index lists all versions for one skill or sub-agent.
 ## Skill Version Detail
 
 Skill version details wrap the exact artifact object that the RFC feed exposes for the same skill version.
+Resourceful skill artifacts use SkillServer's canonical `.zip` archive route, `/skills/{skillName}/{version}/archive.zip`.
 
 ```json
 {

--- a/docs/specs/skills.md
+++ b/docs/specs/skills.md
@@ -119,8 +119,10 @@ Target behavior:
 
 - Skills with only `SKILL.md` should publish as `type: "skill-md"`.
 - Skills with supporting files should publish as `type: "archive"`.
+- SkillServer standardizes archive artifacts on `.zip` at `/skills/{name}/{version}/archive.zip`.
 - Archive artifacts should contain `SKILL.md` at the archive root plus supporting files under their relative paths.
 - The RFC feed and native manifest should point to the same artifact URL and digest for a given skill version.
+- Archive artifact digest and size metadata must be additive. Existing `SKILL.md` digest behavior must remain available for compatibility with current skill download and verification APIs.
 
 Current implementation gap:
 

--- a/src/SkillServer/Data/SkillRepository.cs
+++ b/src/SkillServer/Data/SkillRepository.cs
@@ -98,7 +98,10 @@ public sealed class SkillRepository
             """
             SELECT id AS Id, skill_id AS SkillId, version AS Version, description AS Description,
                    category AS Category, skill_type AS SkillType, sha256 AS Sha256,
-                   size_bytes AS SizeBytes, published_at AS PublishedAt, is_latest AS IsLatest
+                   size_bytes AS SizeBytes,
+                   COALESCE(artifact_sha256, sha256) AS ArtifactSha256,
+                   COALESCE(artifact_size_bytes, size_bytes) AS ArtifactSizeBytes,
+                   published_at AS PublishedAt, is_latest AS IsLatest
             FROM skill_versions
             WHERE skill_id = @skillId AND is_latest = 1
             """,
@@ -112,7 +115,10 @@ public sealed class SkillRepository
             """
             SELECT id AS Id, skill_id AS SkillId, version AS Version, description AS Description,
                    category AS Category, skill_type AS SkillType, sha256 AS Sha256,
-                   size_bytes AS SizeBytes, published_at AS PublishedAt, is_latest AS IsLatest
+                   size_bytes AS SizeBytes,
+                   COALESCE(artifact_sha256, sha256) AS ArtifactSha256,
+                   COALESCE(artifact_size_bytes, size_bytes) AS ArtifactSizeBytes,
+                   published_at AS PublishedAt, is_latest AS IsLatest
             FROM skill_versions
             WHERE skill_id = @skillId AND version = @version
             """,
@@ -126,12 +132,35 @@ public sealed class SkillRepository
             """
             SELECT id AS Id, skill_id AS SkillId, version AS Version, description AS Description,
                    category AS Category, skill_type AS SkillType, sha256 AS Sha256,
-                   size_bytes AS SizeBytes, published_at AS PublishedAt, is_latest AS IsLatest
+                   size_bytes AS SizeBytes,
+                   COALESCE(artifact_sha256, sha256) AS ArtifactSha256,
+                   COALESCE(artifact_size_bytes, size_bytes) AS ArtifactSizeBytes,
+                   published_at AS PublishedAt, is_latest AS IsLatest
             FROM skill_versions
             WHERE skill_id = @skillId
             ORDER BY published_at DESC
             """,
             new { skillId });
+        return versions.ToList();
+    }
+
+    public async Task<IReadOnlyList<SkillVersion>> GetResourcefulVersionsWithoutArchiveAsync(CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        var versions = await connection.QueryAsync<SkillVersion>(
+            """
+            SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
+                   sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
+                   sv.size_bytes AS SizeBytes,
+                   COALESCE(sv.artifact_sha256, sv.sha256) AS ArtifactSha256,
+                   COALESCE(sv.artifact_size_bytes, sv.size_bytes) AS ArtifactSizeBytes,
+                   sv.published_at AS PublishedAt, sv.is_latest AS IsLatest
+            FROM skill_versions sv
+            WHERE sv.skill_type != @archiveType
+              AND EXISTS (SELECT 1 FROM skill_files sf WHERE sf.skill_version_id = sv.id)
+            ORDER BY sv.id
+            """,
+            new { archiveType = SkillTypes.Archive });
         return versions.ToList();
     }
 
@@ -142,7 +171,10 @@ public sealed class SkillRepository
             """
             SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
                    sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
-                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   sv.size_bytes AS SizeBytes,
+                   COALESCE(sv.artifact_sha256, sv.sha256) AS ArtifactSha256,
+                   COALESCE(sv.artifact_size_bytes, sv.size_bytes) AS ArtifactSizeBytes,
+                   sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
                    (SELECT COUNT(*) FROM skill_files sf WHERE sf.skill_version_id = sv.id) AS FileCount
             FROM skill_versions sv
             WHERE sv.skill_id = @skillId
@@ -162,7 +194,10 @@ public sealed class SkillRepository
         var sql = """
             SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
                    sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
-                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   sv.size_bytes AS SizeBytes,
+                   COALESCE(sv.artifact_sha256, sv.sha256) AS ArtifactSha256,
+                   COALESCE(sv.artifact_size_bytes, sv.size_bytes) AS ArtifactSizeBytes,
+                   sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
                    s.name AS SkillName, s.created_at AS SkillCreatedAt, s.updated_at AS SkillUpdatedAt,
                    (SELECT COUNT(*) FROM skill_versions sv2 WHERE sv2.skill_id = s.id) AS VersionCount
             FROM skill_versions sv
@@ -196,7 +231,9 @@ public sealed class SkillRepository
         string skillType,
         string sha256,
         long sizeBytes,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? artifactSha256 = null,
+        long? artifactSizeBytes = null)
     {
         await using var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(ct);
@@ -215,11 +252,23 @@ public sealed class SkillRepository
 
             var versionId = await connection.ExecuteScalarAsync<long>(
                 """
-                INSERT INTO skill_versions (skill_id, version, description, category, skill_type, sha256, size_bytes, published_at, is_latest)
-                VALUES (@skillId, @version, @description, @category, @typeString, @sha256, @sizeBytes, @now, 1);
+                INSERT INTO skill_versions (skill_id, version, description, category, skill_type, sha256, size_bytes, artifact_sha256, artifact_size_bytes, published_at, is_latest)
+                VALUES (@skillId, @version, @description, @category, @typeString, @sha256, @sizeBytes, @artifactSha256, @artifactSizeBytes, @now, 1);
                 SELECT last_insert_rowid();
                 """,
-                new { skillId, version, description, category, typeString, sha256, sizeBytes, now },
+                new
+                {
+                    skillId,
+                    version,
+                    description,
+                    category,
+                    typeString,
+                    sha256,
+                    sizeBytes,
+                    artifactSha256 = artifactSha256 ?? sha256,
+                    artifactSizeBytes = artifactSizeBytes ?? sizeBytes,
+                    now
+                },
                 transaction);
 
             await transaction.CommitAsync(ct);
@@ -230,6 +279,25 @@ public sealed class SkillRepository
             await transaction.RollbackAsync(ct);
             throw;
         }
+    }
+
+    public async Task UpdateVersionArtifactAsync(
+        long versionId,
+        string skillType,
+        string artifactSha256,
+        long artifactSizeBytes,
+        CancellationToken ct = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.ExecuteAsync(
+            """
+            UPDATE skill_versions
+            SET skill_type = @skillType,
+                artifact_sha256 = @artifactSha256,
+                artifact_size_bytes = @artifactSizeBytes
+            WHERE id = @versionId
+            """,
+            new { versionId, skillType, artifactSha256, artifactSizeBytes });
     }
 
     public async Task<IReadOnlyList<SkillFile>> GetFilesAsync(long versionId, CancellationToken ct = default)
@@ -275,7 +343,10 @@ public sealed class SkillRepository
         var sql = """
             SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
                    sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
-                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   sv.size_bytes AS SizeBytes,
+                   COALESCE(sv.artifact_sha256, sv.sha256) AS ArtifactSha256,
+                   COALESCE(sv.artifact_size_bytes, sv.size_bytes) AS ArtifactSizeBytes,
+                   sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
                    s.name AS SkillName, s.created_at AS SkillCreatedAt, s.updated_at AS SkillUpdatedAt,
                    (SELECT COUNT(*) FROM skill_versions sv2 WHERE sv2.skill_id = s.id) AS VersionCount
             FROM skills_fts
@@ -309,7 +380,10 @@ public sealed class SkillRepository
             """
             SELECT sv.id AS Id, sv.skill_id AS SkillId, sv.version AS Version, sv.description AS Description,
                    sv.category AS Category, sv.skill_type AS SkillType, sv.sha256 AS Sha256,
-                   sv.size_bytes AS SizeBytes, sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
+                   sv.size_bytes AS SizeBytes,
+                   COALESCE(sv.artifact_sha256, sv.sha256) AS ArtifactSha256,
+                   COALESCE(sv.artifact_size_bytes, sv.size_bytes) AS ArtifactSizeBytes,
+                   sv.published_at AS PublishedAt, sv.is_latest AS IsLatest,
                    (SELECT COUNT(*) FROM skill_files sf WHERE sf.skill_version_id = sv.id) AS FileCount
             FROM skill_versions sv
             JOIN skills s ON s.id = sv.skill_id

--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -42,6 +42,7 @@ public static class Endpoints
         skills.MapGet("/{name}/latest", GetLatestVersion);
         skills.MapGet("/{name}/{version}", GetVersion);
         skills.MapGet("/{name}/{version}/SKILL.md", DownloadSkillMd);
+        skills.MapGet("/{name}/{version}/archive.zip", DownloadArchive);
         skills.MapGet("/{name}/{version}/{*path}", DownloadResource);
         skills.MapPost("/check-updates", CheckUpdates);
         skills.MapPost("/", UploadSkill).DisableAntiforgery().AddEndpointFilter<ApiKeyEndpointFilter>();
@@ -161,6 +162,28 @@ public static class Endpoints
             return Results.NotFound();
 
         return Results.File(stream, "text/markdown", "SKILL.md");
+    }
+
+    private static async Task<IResult> DownloadArchive(
+        string name,
+        string version,
+        SkillRepository repository,
+        BlobStorage blobStorage,
+        CancellationToken ct)
+    {
+        var skill = await repository.GetSkillByNameAsync(name, ct);
+        if (skill is null)
+            return Results.NotFound();
+
+        var skillVersion = await repository.GetVersionAsync(skill.Id, version, ct);
+        if (skillVersion is null || skillVersion.SkillType != SkillTypes.Archive)
+            return Results.NotFound();
+
+        var stream = blobStorage.GetBlob(skillVersion.ArtifactSha256);
+        if (stream is null)
+            return Results.NotFound();
+
+        return Results.File(stream, "application/zip", "archive.zip");
     }
 
     private static async Task<IResult> DownloadResource(

--- a/src/SkillServer/Models/Skill.cs
+++ b/src/SkillServer/Models/Skill.cs
@@ -29,6 +29,8 @@ public sealed record SkillVersion
     public required string SkillType { get; init; }
     public required string Sha256 { get; init; }
     public required long SizeBytes { get; init; }
+    public required string ArtifactSha256 { get; init; }
+    public required long ArtifactSizeBytes { get; init; }
     public required DateTimeOffset PublishedAt { get; init; }
     public required bool IsLatest { get; init; }
 }
@@ -58,6 +60,8 @@ public sealed record SkillVersionWithFileCount
     public required string SkillType { get; init; }
     public required string Sha256 { get; init; }
     public required long SizeBytes { get; init; }
+    public required string ArtifactSha256 { get; init; }
+    public required long ArtifactSizeBytes { get; init; }
     public required DateTimeOffset PublishedAt { get; init; }
     public required bool IsLatest { get; init; }
     public required int FileCount { get; init; }
@@ -76,6 +80,8 @@ public sealed record SkillVersionWithMetadata
     public required string SkillType { get; init; }
     public required string Sha256 { get; init; }
     public required long SizeBytes { get; init; }
+    public required string ArtifactSha256 { get; init; }
+    public required long ArtifactSizeBytes { get; init; }
     public required DateTimeOffset PublishedAt { get; init; }
     public required bool IsLatest { get; init; }
     public required string SkillName { get; init; }

--- a/src/SkillServer/Program.cs
+++ b/src/SkillServer/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddSingleton<SkillRepository>();
 builder.Services.AddSingleton<ApiKeyRepository>();
 builder.Services.AddSingleton<IndexGenerator>();
 builder.Services.AddSingleton<SkillUploadService>();
+builder.Services.AddSingleton<SkillArchiveBackfillService>();
 builder.Services.AddSingleton<ApiKeyService>();
 
 var app = builder.Build();
@@ -33,6 +34,9 @@ var app = builder.Build();
 // Initialize database
 var dbInitializer = app.Services.GetRequiredService<DatabaseInitializer>();
 await dbInitializer.InitializeAsync();
+
+var archiveBackfillService = app.Services.GetRequiredService<SkillArchiveBackfillService>();
+await archiveBackfillService.BackfillAsync();
 
 // Seed API key from environment variable
 var apiKeyService = app.Services.GetRequiredService<ApiKeyService>();

--- a/src/SkillServer/Services/IndexGenerator.cs
+++ b/src/SkillServer/Services/IndexGenerator.cs
@@ -48,8 +48,8 @@ public sealed class IndexGenerator
                 Description = v.Description,
                 Url = v.SkillType == SkillTypes.SkillMd
                     ? $"{baseUrl}/skills/{v.SkillName}/{v.Version}/SKILL.md"
-                    : $"{baseUrl}/skills/{v.SkillName}/{v.Version}/archive.tar.gz",
-                Digest = Sha256Digest.Create(v.Sha256).Value,
+                    : $"{baseUrl}/skills/{v.SkillName}/{v.Version}/archive.zip",
+                Digest = Sha256Digest.Create(v.ArtifactSha256).Value,
                 Version = v.Version,
                 Resources = files.Count > 0
                     ? files.Select(f => new RfcResourceEntry

--- a/src/SkillServer/Services/SkillArchiveBackfillService.cs
+++ b/src/SkillServer/Services/SkillArchiveBackfillService.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillArchiveBackfillService.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using SkillServer.Data;
+using SkillServer.Models;
+
+namespace SkillServer.Services;
+
+public sealed class SkillArchiveBackfillService
+{
+    private readonly SkillRepository _repository;
+    private readonly BlobStorage _blobStorage;
+    private readonly ILogger<SkillArchiveBackfillService> _logger;
+
+    public SkillArchiveBackfillService(
+        SkillRepository repository,
+        BlobStorage blobStorage,
+        ILogger<SkillArchiveBackfillService> logger)
+    {
+        _repository = repository;
+        _blobStorage = blobStorage;
+        _logger = logger;
+    }
+
+    public async Task BackfillAsync(CancellationToken ct = default)
+    {
+        var versions = await _repository.GetResourcefulVersionsWithoutArchiveAsync(ct);
+        if (versions.Count == 0)
+            return;
+
+        _logger.LogInformation("Backfilling archive artifacts for {Count} resourceful skill version(s)", versions.Count);
+
+        foreach (var version in versions)
+        {
+            await BackfillVersionAsync(version, ct);
+        }
+    }
+
+    private async Task BackfillVersionAsync(SkillVersion version, CancellationToken ct)
+    {
+        var skillMdBytes = await ReadBlobBytesAsync(version.Sha256, ct);
+        if (skillMdBytes is null)
+        {
+            _logger.LogWarning("Skipping archive backfill for skill version id {VersionId}: SKILL.md blob {Digest} is missing", version.Id, version.Sha256);
+            return;
+        }
+
+        var files = await _repository.GetFilesAsync(version.Id, ct);
+        var resources = new List<(ResourcePath Path, byte[] Content)>(files.Count);
+
+        foreach (var file in files)
+        {
+            if (!ResourcePath.TryCreate(file.RelativePath, out var resourcePath))
+            {
+                _logger.LogWarning("Skipping archive backfill for skill version id {VersionId}: invalid resource path {Path}", version.Id, file.RelativePath);
+                return;
+            }
+
+            var content = await ReadBlobBytesAsync(file.Sha256, ct);
+            if (content is null)
+            {
+                _logger.LogWarning("Skipping archive backfill for skill version id {VersionId}: resource blob {Digest} is missing", version.Id, file.Sha256);
+                return;
+            }
+
+            resources.Add((resourcePath.Value, content));
+        }
+
+        var archiveBytes = SkillArchiveBuilder.BuildZip(skillMdBytes, resources);
+        var (archiveDigest, archiveSizeBytes) = await _blobStorage.StoreAsync(archiveBytes, ct);
+        var parsedArchiveDigest = Sha256Digest.Create(archiveDigest);
+
+        await _repository.UpdateVersionArtifactAsync(
+            version.Id, SkillTypes.Archive, parsedArchiveDigest.Value, archiveSizeBytes, ct);
+    }
+
+    private async Task<byte[]?> ReadBlobBytesAsync(string digest, CancellationToken ct)
+    {
+        await using var stream = _blobStorage.GetBlob(digest);
+        if (stream is null)
+            return null;
+
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, ct);
+        return buffer.ToArray();
+    }
+}

--- a/src/SkillServer/Services/SkillArchiveBuilder.cs
+++ b/src/SkillServer/Services/SkillArchiveBuilder.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillArchiveBuilder.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.IO.Compression;
+using SkillServer.Models;
+
+namespace SkillServer.Services;
+
+internal static class SkillArchiveBuilder
+{
+    private static readonly DateTimeOffset FixedTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public static byte[] BuildZip(
+        byte[] skillMdContent,
+        IReadOnlyList<(ResourcePath Path, byte[] Content)> resources)
+    {
+        using var archiveStream = new MemoryStream();
+        using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "SKILL.md", skillMdContent);
+
+            foreach (var resource in resources.OrderBy(r => r.Path.Value, StringComparer.Ordinal))
+            {
+                AddEntry(archive, resource.Path.Value, resource.Content);
+            }
+        }
+
+        return archiveStream.ToArray();
+    }
+
+    private static void AddEntry(ZipArchive archive, string path, byte[] content)
+    {
+        var entry = archive.CreateEntry(path, CompressionLevel.NoCompression);
+        entry.LastWriteTime = FixedTimestamp;
+        entry.ExternalAttributes = 0;
+
+        using var entryStream = entry.Open();
+        entryStream.Write(content);
+    }
+}

--- a/src/SkillServer/Services/SkillUploadService.cs
+++ b/src/SkillServer/Services/SkillUploadService.cs
@@ -125,8 +125,24 @@ public sealed partial class SkillUploadService
         string? category = null,
         CancellationToken ct = default)
     {
+        if (resources.Count == 0)
+            return await UploadSkillMdAsync(name, version, skillMdContent, category, ct);
+
+        using var skillMdBuffer = new MemoryStream();
+        await skillMdContent.CopyToAsync(skillMdBuffer, ct);
+        var skillMdBytes = skillMdBuffer.ToArray();
+
+        var resourceContents = new List<(ResourcePath Path, byte[] Content)>(resources.Count);
+        foreach (var (resourcePath, content) in resources)
+        {
+            using var resourceBuffer = new MemoryStream();
+            await content.CopyToAsync(resourceBuffer, ct);
+            resourceContents.Add((resourcePath, resourceBuffer.ToArray()));
+        }
+
         // First upload the SKILL.md
-        var result = await UploadSkillMdAsync(name, version, skillMdContent, category, ct);
+        using var skillMdUploadStream = new MemoryStream(skillMdBytes, writable: false);
+        var result = await UploadSkillMdAsync(name, version, skillMdUploadStream, category, ct);
         if (!result.Success)
             return result;
 
@@ -138,13 +154,21 @@ public sealed partial class SkillUploadService
         if (skillVersion is null) return SkillUploadResult.Failed("Version not found after upload.");
 
         // Store resource files
-        foreach (var (resourcePath, content) in resources)
+        foreach (var (resourcePath, contentBytes) in resourceContents)
         {
-            var (digest, sizeBytes) = await _blobStorage.StoreAsync(content, ct);
+            var (digest, sizeBytes) = await _blobStorage.StoreAsync(contentBytes, ct);
             var parsedDigest = Sha256Digest.Create(digest);
             await _repository.AddFileAsync(skillVersion.Id, resourcePath.Value, parsedDigest.Value, sizeBytes, ct);
             _logger.LogDebug("Added resource {Path} ({Digest})", resourcePath.Value, parsedDigest.Value);
         }
+
+        var archiveBytes = SkillArchiveBuilder.BuildZip(skillMdBytes, resourceContents);
+        var (archiveDigest, archiveSizeBytes) = await _blobStorage.StoreAsync(archiveBytes, ct);
+        var parsedArchiveDigest = Sha256Digest.Create(archiveDigest);
+        await _repository.UpdateVersionArtifactAsync(
+            skillVersion.Id, SkillTypes.Archive, parsedArchiveDigest.Value, archiveSizeBytes, ct);
+
+        _logger.LogDebug("Added archive artifact for {Name} {Version} ({Digest})", name.Value, version.Value, parsedArchiveDigest.Value);
 
         return result;
     }

--- a/src/SkillServer/migrations/003_skill_artifact_metadata.sql
+++ b/src/SkillServer/migrations/003_skill_artifact_metadata.sql
@@ -1,0 +1,15 @@
+-- 003_skill_artifact_metadata.sql: Track canonical artifact bytes separately from SKILL.md bytes
+
+ALTER TABLE skill_versions ADD COLUMN artifact_sha256 TEXT;
+ALTER TABLE skill_versions ADD COLUMN artifact_size_bytes INTEGER;
+
+UPDATE skill_versions
+SET artifact_sha256 = sha256
+WHERE artifact_sha256 IS NULL;
+
+UPDATE skill_versions
+SET artifact_size_bytes = size_bytes
+WHERE artifact_size_bytes IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_skill_versions_artifact_sha256
+    ON skill_versions(artifact_sha256);

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -6,6 +6,8 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.IO.Compression;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Netclaw.SkillClient;
@@ -21,6 +23,12 @@ public sealed class SkillServerIntegrationTests
     public SkillServerIntegrationTests(SkillServerFixture fixture)
     {
         _fixture = fixture;
+    }
+
+    private static string ComputeSha256Digest(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
     }
 
     [Fact]
@@ -92,6 +100,9 @@ public sealed class SkillServerIntegrationTests
         var index = await _fixture.Client.GetRfcIndexAsync(ct);
         Assert.NotNull(index);
         Assert.Contains(index.Skills, s => s.Name == skillName);
+        var indexSkill = Assert.Single(index.Skills, s => s.Name == skillName);
+        Assert.Equal("skill-md", indexSkill.Type);
+        Assert.EndsWith($"/skills/{skillName}/1.0.0/SKILL.md", indexSkill.Url, StringComparison.Ordinal);
 
         // Get skill versions
         var versions = await _fixture.Client.GetSkillVersionsAsync(skillName, ct);
@@ -684,6 +695,32 @@ public sealed class SkillServerIntegrationTests
         Assert.NotNull(index);
         var indexSkill = index.Skills.FirstOrDefault(s => s.Name == skillName);
         Assert.NotNull(indexSkill);
+        Assert.Equal("archive", indexSkill!.Type);
+        Assert.EndsWith($"/skills/{skillName}/1.0.0/archive.zip", indexSkill.Url, StringComparison.Ordinal);
+        Assert.NotEqual(version.Sha256, indexSkill.Digest);
+
+        var skillMdVerified = await _fixture.Client.VerifyDigestAsync(skillName, "1.0.0", version.Sha256, ct);
+        Assert.True(skillMdVerified);
+
+        var archiveResponse = await _fixture.HttpClient.GetAsync($"/skills/{skillName}/1.0.0/archive.zip", ct);
+        Assert.Equal(HttpStatusCode.OK, archiveResponse.StatusCode);
+        Assert.Equal("application/zip", archiveResponse.Content.Headers.ContentType?.MediaType);
+
+        var archiveBytes = await archiveResponse.Content.ReadAsByteArrayAsync(ct);
+        Assert.Equal(indexSkill.Digest, ComputeSha256Digest(archiveBytes));
+
+        using var archiveStream = new MemoryStream(archiveBytes);
+        using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Read);
+        Assert.Equal([
+            "SKILL.md",
+            "references/guide.md",
+            "scripts/setup.sh"
+        ], archive.Entries.Select(e => e.FullName).ToArray());
+
+        using var archivedSkillReader = new StreamReader(archive.GetEntry("SKILL.md")!.Open());
+        var archivedSkill = await archivedSkillReader.ReadToEndAsync(ct);
+        Assert.Contains("# Resource Upload Test", archivedSkill);
+
         var resources = indexSkill!.Resources;
         Assert.NotNull(resources);
         Assert.Equal(2, resources!.Count);

--- a/tests/SkillServer.Tests/SkillArchiveBackfillServiceTests.cs
+++ b/tests/SkillServer.Tests/SkillArchiveBackfillServiceTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.IO.Compression;
 using System.Text;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using SkillServer.Data;
@@ -82,6 +83,8 @@ public sealed class SkillArchiveBackfillServiceTests : IDisposable
 
     public void Dispose()
     {
+        SqliteConnection.ClearAllPools();
+
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
     }

--- a/tests/SkillServer.Tests/SkillArchiveBackfillServiceTests.cs
+++ b/tests/SkillServer.Tests/SkillArchiveBackfillServiceTests.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillArchiveBackfillServiceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.IO.Compression;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using SkillServer.Data;
+using SkillServer.Models;
+using SkillServer.Services;
+using Xunit;
+
+namespace SkillServer.Tests;
+
+public sealed class SkillArchiveBackfillServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SkillArchiveBackfillServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"skillserver-backfill-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public async Task BackfillAsync_ConvertsLegacyResourcefulSkillToArchiveArtifact()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SkillServer:DataPath"] = _tempDir
+            })
+            .Build();
+
+        var initializer = new DatabaseInitializer(configuration, NullLogger<DatabaseInitializer>.Instance);
+        await initializer.InitializeAsync(ct);
+
+        var repository = new SkillRepository(initializer);
+        var blobStorage = new BlobStorage(configuration, NullLogger<BlobStorage>.Instance);
+        var backfillService = new SkillArchiveBackfillService(
+            repository,
+            blobStorage,
+            NullLogger<SkillArchiveBackfillService>.Instance);
+
+        const string skillName = "legacy-resourceful";
+        var skillMdBytes = Encoding.UTF8.GetBytes($"---\nname: {skillName}\ndescription: Legacy resourceful skill\n---\n# Legacy");
+        var resourceBytes = Encoding.UTF8.GetBytes("# Guide");
+
+        var (skillDigest, skillSizeBytes) = await blobStorage.StoreAsync(skillMdBytes, ct);
+        var (resourceDigest, resourceSizeBytes) = await blobStorage.StoreAsync(resourceBytes, ct);
+
+        var skillId = await repository.CreateSkillAsync(skillName, ct);
+        var versionId = await repository.CreateVersionAsync(
+            skillId,
+            "1.0.0",
+            "Legacy resourceful skill",
+            null,
+            SkillTypes.SkillMd,
+            skillDigest,
+            skillSizeBytes,
+            ct);
+        await repository.AddFileAsync(versionId, "references/guide.md", resourceDigest, resourceSizeBytes, ct);
+
+        await backfillService.BackfillAsync(ct);
+
+        var version = await repository.GetVersionAsync(skillId, "1.0.0", ct);
+        Assert.NotNull(version);
+        Assert.Equal(SkillTypes.Archive, version.SkillType);
+        Assert.Equal(skillDigest, version.Sha256);
+        Assert.NotEqual(version.Sha256, version.ArtifactSha256);
+        Assert.True(version.ArtifactSizeBytes > version.SizeBytes);
+
+        await using var archiveBlob = blobStorage.GetBlob(version.ArtifactSha256);
+        Assert.NotNull(archiveBlob);
+
+        using var archive = new ZipArchive(archiveBlob!, ZipArchiveMode.Read);
+        Assert.Equal(["SKILL.md", "references/guide.md"], archive.Entries.Select(e => e.FullName).ToArray());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}

--- a/tests/SkillServer.Tests/SkillArchiveBuilderTests.cs
+++ b/tests/SkillServer.Tests/SkillArchiveBuilderTests.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillArchiveBuilderTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.IO.Compression;
+using System.Text;
+using SkillServer.Models;
+using SkillServer.Services;
+using Xunit;
+
+namespace SkillServer.Tests;
+
+public sealed class SkillArchiveBuilderTests
+{
+    [Fact]
+    public void BuildZip_IsDeterministicAndUsesExpectedLayout()
+    {
+        var skillMd = Encoding.UTF8.GetBytes("---\nname: test\ndescription: test\n---\n# Test");
+        var guide = Encoding.UTF8.GetBytes("# Guide");
+        var script = Encoding.UTF8.GetBytes("#!/bin/bash\necho setup");
+
+        var resources = new List<(ResourcePath Path, byte[] Content)>
+        {
+            (ResourcePath.Create("scripts/setup.sh"), script),
+            (ResourcePath.Create("references/guide.md"), guide)
+        };
+
+        var reversedResources = resources.AsEnumerable().Reverse().ToList();
+
+        var first = SkillArchiveBuilder.BuildZip(skillMd, resources);
+        var second = SkillArchiveBuilder.BuildZip(skillMd, reversedResources);
+
+        Assert.Equal(first, second);
+
+        using var archiveStream = new MemoryStream(first);
+        using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Read);
+
+        Assert.Equal([
+            "SKILL.md",
+            "references/guide.md",
+            "scripts/setup.sh"
+        ], archive.Entries.Select(e => e.FullName).ToArray());
+
+        Assert.All(archive.Entries, entry =>
+            Assert.Equal(new DateTimeOffset(1980, 1, 1, 0, 0, 0, TimeSpan.Zero), entry.LastWriteTime));
+    }
+}


### PR DESCRIPTION
## Summary
- standardize resourceful skill artifacts on deterministic archive.zip downloads
- preserve SKILL.md digest behavior with additive artifact metadata
- backfill archive artifacts for existing resourceful skill versions

Closes #86

## Verification
- dotnet build -c Release
- dotnet test -c Release
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- dotnet slopwatch analyze