### PR TITLE
Add native sub-agent manifest endpoints

### DIFF
--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -88,6 +88,48 @@ public static class Endpoints
                 ? Results.NotFound()
                 : Results.Json(skillVersion, SkillServerJsonContext.Default.NativeSkillVersionDetail);
         });
+
+        manifest.MapGet("/subagents/index.json", async (
+            NativeManifestGenerator manifestGenerator,
+            CancellationToken ct) =>
+        {
+            var index = await manifestGenerator.GenerateSubAgentIndexAsync(ct);
+            return Results.Json(index, SkillServerJsonContext.Default.NativeSubAgentCollectionIndex);
+        });
+
+        manifest.MapGet("/subagents/pages/{page}.json", async (
+            string page,
+            NativeManifestGenerator manifestGenerator,
+            CancellationToken ct) =>
+        {
+            var subAgentPage = await manifestGenerator.GenerateSubAgentPageAsync(page, ct);
+            return subAgentPage is null
+                ? Results.NotFound()
+                : Results.Json(subAgentPage, SkillServerJsonContext.Default.NativeSubAgentCollectionPage);
+        });
+
+        manifest.MapGet("/subagents/{subAgentName}/index.json", async (
+            string subAgentName,
+            NativeManifestGenerator manifestGenerator,
+            CancellationToken ct) =>
+        {
+            var subAgent = await manifestGenerator.GenerateSubAgentIdentityAsync(subAgentName, ct);
+            return subAgent is null
+                ? Results.NotFound()
+                : Results.Json(subAgent, SkillServerJsonContext.Default.NativeSubAgentIdentityIndex);
+        });
+
+        manifest.MapGet("/subagents/{subAgentName}/versions/{version}.json", async (
+            string subAgentName,
+            string version,
+            NativeManifestGenerator manifestGenerator,
+            CancellationToken ct) =>
+        {
+            var subAgentVersion = await manifestGenerator.GenerateSubAgentVersionAsync(subAgentName, version, ct);
+            return subAgentVersion is null
+                ? Results.NotFound()
+                : Results.Json(subAgentVersion, SkillServerJsonContext.Default.NativeSubAgentVersionDetail);
+        });
     }
 
     private static void MapSkillEndpoints(this WebApplication app)

--- a/src/SkillServer/Models/NativeManifest.cs
+++ b/src/SkillServer/Models/NativeManifest.cs
@@ -29,6 +29,9 @@ public sealed record NativeRootManifestLinks
 
     [JsonPropertyName("skills")]
     public required NativeManifestLink Skills { get; init; }
+
+    [JsonPropertyName("subagents")]
+    public required NativeManifestLink SubAgents { get; init; }
 }
 
 public sealed record NativeRootManifest
@@ -64,6 +67,18 @@ public sealed record NativeSkillCollectionIndex
     public required IReadOnlyList<NativeManifestPageLink> Pages { get; init; }
 }
 
+public sealed record NativeSubAgentCollectionIndex
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "subagent-index";
+
+    [JsonPropertyName("links")]
+    public required NativeManifestSelfLinks Links { get; init; }
+
+    [JsonPropertyName("pages")]
+    public required IReadOnlyList<NativeManifestPageLink> Pages { get; init; }
+}
+
 public sealed record NativeVersionRange
 {
     [JsonPropertyName("min")]
@@ -77,6 +92,21 @@ public sealed record NativeVersionRange
 }
 
 public sealed record NativeSkillPageItem
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("latestVersion")]
+    public required string LatestVersion { get; init; }
+
+    [JsonPropertyName("versionRange")]
+    public required NativeVersionRange VersionRange { get; init; }
+
+    [JsonPropertyName("href")]
+    public required string Href { get; init; }
+}
+
+public sealed record NativeSubAgentPageItem
 {
     [JsonPropertyName("name")]
     public required string Name { get; init; }
@@ -106,7 +136,37 @@ public sealed record NativeSkillCollectionPage
     public required NativeManifestSelfLinks Links { get; init; }
 }
 
+public sealed record NativeSubAgentCollectionPage
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "subagent-page";
+
+    [JsonPropertyName("range")]
+    public required string Range { get; init; }
+
+    [JsonPropertyName("items")]
+    public required IReadOnlyList<NativeSubAgentPageItem> Items { get; init; }
+
+    [JsonPropertyName("links")]
+    public required NativeManifestSelfLinks Links { get; init; }
+}
+
 public sealed record NativeSkillVersionLink
+{
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("publishedAt")]
+    public required DateTimeOffset PublishedAt { get; init; }
+
+    [JsonPropertyName("digest")]
+    public required string Digest { get; init; }
+
+    [JsonPropertyName("href")]
+    public required string Href { get; init; }
+}
+
+public sealed record NativeSubAgentVersionLink
 {
     [JsonPropertyName("version")]
     public required string Version { get; init; }
@@ -134,6 +194,24 @@ public sealed record NativeSkillIdentityIndex
 
     [JsonPropertyName("versions")]
     public required IReadOnlyList<NativeSkillVersionLink> Versions { get; init; }
+
+    [JsonPropertyName("links")]
+    public required NativeManifestSelfLinks Links { get; init; }
+}
+
+public sealed record NativeSubAgentIdentityIndex
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "subagent";
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("latestVersion")]
+    public required string LatestVersion { get; init; }
+
+    [JsonPropertyName("versions")]
+    public required IReadOnlyList<NativeSubAgentVersionLink> Versions { get; init; }
 
     [JsonPropertyName("links")]
     public required NativeManifestSelfLinks Links { get; init; }
@@ -179,6 +257,33 @@ public sealed record NativeSkillVersionDetail
 
     [JsonPropertyName("routesToSubagent")]
     public NativeSubagentRoute? RoutesToSubagent { get; init; }
+
+    [JsonPropertyName("links")]
+    public required NativeManifestSelfLinks Links { get; init; }
+}
+
+public sealed record NativeSubAgentVersionDetail
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "subagent-version";
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = SubAgentTypes.AgentMd;
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+
+    [JsonPropertyName("digest")]
+    public required string Digest { get; init; }
 
     [JsonPropertyName("links")]
     public required NativeManifestSelfLinks Links { get; init; }

--- a/src/SkillServer/Models/SkillServerJsonContext.cs
+++ b/src/SkillServer/Models/SkillServerJsonContext.cs
@@ -37,6 +37,10 @@ namespace SkillServer.Models;
 [JsonSerializable(typeof(NativeSkillCollectionPage))]
 [JsonSerializable(typeof(NativeSkillIdentityIndex))]
 [JsonSerializable(typeof(NativeSkillVersionDetail))]
+[JsonSerializable(typeof(NativeSubAgentCollectionIndex))]
+[JsonSerializable(typeof(NativeSubAgentCollectionPage))]
+[JsonSerializable(typeof(NativeSubAgentIdentityIndex))]
+[JsonSerializable(typeof(NativeSubAgentVersionDetail))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/SkillServer/Services/NativeManifestGenerator.cs
+++ b/src/SkillServer/Services/NativeManifestGenerator.cs
@@ -11,13 +11,19 @@ namespace SkillServer.Services;
 public sealed class NativeManifestGenerator
 {
     private const string SkillsPageRange = "all";
+    private const string SubAgentsPageRange = "all";
 
-    private readonly SkillRepository _repository;
+    private readonly SkillRepository _skillRepository;
+    private readonly SubAgentRepository _subAgentRepository;
     private readonly IConfiguration _configuration;
 
-    public NativeManifestGenerator(SkillRepository repository, IConfiguration configuration)
+    public NativeManifestGenerator(
+        SkillRepository skillRepository,
+        SubAgentRepository subAgentRepository,
+        IConfiguration configuration)
     {
-        _repository = repository;
+        _skillRepository = skillRepository;
+        _subAgentRepository = subAgentRepository;
         _configuration = configuration;
     }
 
@@ -30,7 +36,8 @@ public sealed class NativeManifestGenerator
             {
                 Self = Link("/manifest.json"),
                 RfcSkills = Link("/.well-known/agent-skills/index.json"),
-                Skills = Link("/manifest/skills/index.json")
+                Skills = Link("/manifest/skills/index.json"),
+                SubAgents = Link("/manifest/subagents/index.json")
             }
         };
 
@@ -57,12 +64,12 @@ public sealed class NativeManifestGenerator
         if (!page.Equals(SkillsPageRange, StringComparison.OrdinalIgnoreCase))
             return null;
 
-        var latestVersions = await _repository.GetAllLatestVersionsWithMetadataAsync(ct: ct);
+        var latestVersions = await _skillRepository.GetAllLatestVersionsWithMetadataAsync(ct: ct);
         var items = new List<NativeSkillPageItem>(latestVersions.Count);
 
         foreach (var latest in latestVersions)
         {
-            var versions = await _repository.GetAllVersionsAsync(latest.SkillId, ct);
+            var versions = await _skillRepository.GetAllVersionsAsync(latest.SkillId, ct);
             if (versions.Count == 0)
                 continue;
 
@@ -91,11 +98,11 @@ public sealed class NativeManifestGenerator
 
     public async Task<NativeSkillIdentityIndex?> GenerateSkillIdentityAsync(string skillName, CancellationToken ct = default)
     {
-        var skill = await _repository.GetSkillByNameAsync(skillName, ct);
+        var skill = await _skillRepository.GetSkillByNameAsync(skillName, ct);
         if (skill is null)
             return null;
 
-        var versions = await _repository.GetAllVersionsAsync(skill.Id, ct);
+        var versions = await _skillRepository.GetAllVersionsAsync(skill.Id, ct);
         if (versions.Count == 0)
             return null;
 
@@ -117,11 +124,11 @@ public sealed class NativeManifestGenerator
 
     public async Task<NativeSkillVersionDetail?> GenerateSkillVersionAsync(string skillName, string version, CancellationToken ct = default)
     {
-        var skill = await _repository.GetSkillByNameAsync(skillName, ct);
+        var skill = await _skillRepository.GetSkillByNameAsync(skillName, ct);
         if (skill is null)
             return null;
 
-        var skillVersion = await _repository.GetVersionAsync(skill.Id, version, ct);
+        var skillVersion = await _skillRepository.GetVersionAsync(skill.Id, version, ct);
         if (skillVersion is null)
             return null;
 
@@ -136,6 +143,106 @@ public sealed class NativeManifestGenerator
                     Href = $"/manifest/subagents/{skillVersion.RoutesToSubagent}/index.json"
                 },
             Links = SelfLinks($"/manifest/skills/{skill.Name}/versions/{skillVersion.Version}.json")
+        };
+    }
+
+    public Task<NativeSubAgentCollectionIndex> GenerateSubAgentIndexAsync(CancellationToken ct = default)
+    {
+        var index = new NativeSubAgentCollectionIndex
+        {
+            Links = SelfLinks("/manifest/subagents/index.json"),
+            Pages = [new NativeManifestPageLink
+            {
+                Range = SubAgentsPageRange,
+                Href = "/manifest/subagents/pages/all.json"
+            }]
+        };
+
+        return Task.FromResult(index);
+    }
+
+    public async Task<NativeSubAgentCollectionPage?> GenerateSubAgentPageAsync(string page, CancellationToken ct = default)
+    {
+        if (!page.Equals(SubAgentsPageRange, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var latestVersions = await _subAgentRepository.GetAllLatestVersionsWithMetadataAsync(ct);
+        var items = new List<NativeSubAgentPageItem>(latestVersions.Count);
+
+        foreach (var latest in latestVersions)
+        {
+            var versions = await _subAgentRepository.GetAllVersionsAsync(latest.SubAgentId, ct);
+            if (versions.Count == 0)
+                continue;
+
+            var oldest = versions[^1];
+            items.Add(new NativeSubAgentPageItem
+            {
+                Name = latest.SubAgentName,
+                LatestVersion = latest.Version,
+                VersionRange = new NativeVersionRange
+                {
+                    Min = oldest.Version,
+                    Max = latest.Version,
+                    Count = versions.Count
+                },
+                Href = $"/manifest/subagents/{latest.SubAgentName}/index.json"
+            });
+        }
+
+        return new NativeSubAgentCollectionPage
+        {
+            Range = SubAgentsPageRange,
+            Items = items,
+            Links = SelfLinks("/manifest/subagents/pages/all.json")
+        };
+    }
+
+    public async Task<NativeSubAgentIdentityIndex?> GenerateSubAgentIdentityAsync(string subAgentName, CancellationToken ct = default)
+    {
+        var subAgent = await _subAgentRepository.GetSubAgentByNameAsync(subAgentName, ct);
+        if (subAgent is null)
+            return null;
+
+        var versions = await _subAgentRepository.GetAllVersionsAsync(subAgent.Id, ct);
+        if (versions.Count == 0)
+            return null;
+
+        var latest = versions.FirstOrDefault(v => v.IsLatest) ?? versions[0];
+        return new NativeSubAgentIdentityIndex
+        {
+            Name = subAgent.Name,
+            LatestVersion = latest.Version,
+            Versions = versions.Select(v => new NativeSubAgentVersionLink
+            {
+                Version = v.Version,
+                PublishedAt = v.PublishedAt,
+                Digest = Sha256Digest.Create(v.Sha256).Value,
+                Href = $"/manifest/subagents/{subAgent.Name}/versions/{v.Version}.json"
+            }).ToList(),
+            Links = SelfLinks($"/manifest/subagents/{subAgent.Name}/index.json")
+        };
+    }
+
+    public async Task<NativeSubAgentVersionDetail?> GenerateSubAgentVersionAsync(string subAgentName, string version, CancellationToken ct = default)
+    {
+        var subAgent = await _subAgentRepository.GetSubAgentByNameAsync(subAgentName, ct);
+        if (subAgent is null)
+            return null;
+
+        var subAgentVersion = await _subAgentRepository.GetVersionAsync(subAgent.Id, version, ct);
+        if (subAgentVersion is null)
+            return null;
+
+        var baseUrl = GetBaseUrl();
+        return new NativeSubAgentVersionDetail
+        {
+            Name = subAgent.Name,
+            Version = subAgentVersion.Version,
+            Description = subAgentVersion.Description,
+            Url = $"{baseUrl}/subagents/{subAgent.Name}/{subAgentVersion.Version}/agent.md",
+            Digest = Sha256Digest.Create(subAgentVersion.Sha256).Value,
+            Links = SelfLinks($"/manifest/subagents/{subAgent.Name}/versions/{subAgentVersion.Version}.json")
         };
     }
 

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -169,6 +169,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal("/manifest.json", root.Links.Self.Href);
         Assert.Equal("/.well-known/agent-skills/index.json", root.Links.RfcSkills.Href);
         Assert.Equal("/manifest/skills/index.json", root.Links.Skills.Href);
+        Assert.Equal("/manifest/subagents/index.json", root.Links.SubAgents.Href);
 
         var skillIndex = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSkillCollectionIndex>(
             root.Links.Skills.Href, ct);
@@ -266,6 +267,74 @@ public sealed class SkillServerIntegrationTests
         var artifactBytes = await artifactResponse.Content.ReadAsByteArrayAsync(ct);
         Assert.Equal(upload.Sha256, ComputeSha256Digest(artifactBytes));
         Assert.Contains("technical support diagnostician", Encoding.UTF8.GetString(artifactBytes));
+
+        var rfcIndex = await _fixture.Client.GetRfcIndexAsync(ct);
+        Assert.NotNull(rfcIndex);
+        Assert.DoesNotContain(rfcIndex.Skills, s => s.Name == subAgentName);
+    }
+
+    [Fact]
+    public async Task NativeManifest_SubAgentTraversal_ReturnsAgentArtifactValues()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var subAgentName = $"manifest-agent-{Guid.NewGuid():N}"[..20];
+
+        var agentMd = $"""
+            ---
+            name: {subAgentName}
+            description: Native manifest sub-agent test.
+            modelRole: Compaction
+            timeoutSeconds: 90
+            visibility: user-facing
+            ---
+
+            You are a manifest-tested sub-agent.
+            """;
+
+        using var content = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", content, ct);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+
+        var root = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeRootManifest>("/manifest.json", ct);
+        Assert.NotNull(root);
+        Assert.Equal("/manifest/subagents/index.json", root.Links.SubAgents.Href);
+
+        var subAgentIndex = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentCollectionIndex>(
+            root.Links.SubAgents.Href, ct);
+        Assert.NotNull(subAgentIndex);
+        Assert.Equal("subagent-index", subAgentIndex.Kind);
+        var pageLink = Assert.Single(subAgentIndex.Pages);
+
+        var subAgentPage = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentCollectionPage>(
+            pageLink.Href, ct);
+        Assert.NotNull(subAgentPage);
+        Assert.Equal("subagent-page", subAgentPage.Kind);
+        var item = Assert.Single(subAgentPage.Items, i => i.Name == subAgentName);
+        Assert.Equal("1.0.0", item.LatestVersion);
+        Assert.Equal($"/manifest/subagents/{subAgentName}/index.json", item.Href);
+
+        var identity = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentIdentityIndex>(
+            item.Href, ct);
+        Assert.NotNull(identity);
+        Assert.Equal("subagent", identity.Kind);
+        Assert.Equal(subAgentName, identity.Name);
+        var versionLink = Assert.Single(identity.Versions, v => v.Version == "1.0.0");
+
+        var detail = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentVersionDetail>(
+            versionLink.Href, ct);
+        Assert.NotNull(detail);
+        Assert.Equal("subagent-version", detail.Kind);
+        Assert.Equal(subAgentName, detail.Name);
+        Assert.Equal("1.0.0", detail.Version);
+        Assert.Equal("agent-md", detail.Type);
+        Assert.Equal("Native manifest sub-agent test.", detail.Description);
+        Assert.EndsWith($"/subagents/{subAgentName}/1.0.0/agent.md", detail.Url, StringComparison.Ordinal);
+
+        var artifactResponse = await _fixture.HttpClient.GetAsync($"/subagents/{subAgentName}/1.0.0/agent.md", ct);
+        Assert.Equal(HttpStatusCode.OK, artifactResponse.StatusCode);
+        var artifactBytes = await artifactResponse.Content.ReadAsByteArrayAsync(ct);
+        Assert.Equal(detail.Digest, ComputeSha256Digest(artifactBytes));
+        Assert.Equal(detail.Digest, versionLink.Digest);
 
         var rfcIndex = await _fixture.Client.GetRfcIndexAsync(ct);
         Assert.NotNull(rfcIndex);


### PR DESCRIPTION
Closes #89

## Summary
- add native sub-agent manifest collection, identity, and version documents
- expose /manifest/subagents traversal routes from the root native manifest
- verify sub-agent manifest traversal and RFC skill feed isolation

## Tests
- dotnet build -c Release
- dotnet test -c Release
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- dotnet slopwatch analyze
- git diff --check