### PR TITLE
Add CLI sub-agent workflows

### DIFF
--- a/src/Netclaw.SkillServer.Cli/Commands/DownloadSubAgentCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/DownloadSubAgentCommand.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="DownloadSubAgentCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Output;
+using Netclaw.SkillServer.Cli.Publishing;
+
+namespace Netclaw.SkillServer.Cli.Commands;
+
+internal static class DownloadSubAgentCommand
+{
+    public static async Task<int> ExecuteAsync(ParsedArgs args, SkillServerClient client)
+    {
+        if (args.Help || args.Positional.Count < 3)
+        {
+            PrintHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        var name = args.Positional[0];
+        var version = args.Positional[1];
+        var destinationPath = Path.GetFullPath(args.Positional[2]);
+
+        if (!SubAgentFileScanner.IsValidName(name))
+        {
+            ConsoleOutput.WriteError("Error: Invalid sub-agent name.");
+            return 1;
+        }
+
+        if (!SubAgentFileScanner.IsValidVersion(version))
+        {
+            ConsoleOutput.WriteError("Error: Invalid sub-agent version.");
+            return 1;
+        }
+
+        if (File.Exists(destinationPath) && !args.Force)
+        {
+            ConsoleOutput.WriteError($"Error: Destination '{destinationPath}' already exists. Use --force to overwrite.");
+            return 1;
+        }
+
+        if (args.DryRun)
+        {
+            ConsoleOutput.WriteWarning(
+                $"Dry run: would download sub-agent {name}@{version} to {destinationPath}");
+            return 0;
+        }
+
+        try
+        {
+            var detail = await client.GetNativeSubAgentVersionAsync(name, version);
+            if (detail is null)
+            {
+                ConsoleOutput.WriteError($"Error: Sub-agent {name}@{version} not found.");
+                return 1;
+            }
+
+            if (!detail.Type.Equals(SubAgentArtifactTypes.AgentMd, StringComparison.OrdinalIgnoreCase))
+            {
+                ConsoleOutput.WriteError($"Error: Unsupported sub-agent artifact type '{detail.Type}'.");
+                return 1;
+            }
+
+            var parentDirectory = Path.GetDirectoryName(destinationPath);
+            if (!string.IsNullOrEmpty(parentDirectory))
+                Directory.CreateDirectory(parentDirectory);
+
+            var tempPath = $"{destinationPath}.tmp-{Guid.NewGuid():N}";
+            try
+            {
+                await using (var destination = File.Create(tempPath))
+                {
+                    if (args.Verbose)
+                        ConsoleOutput.WriteDim($"  Downloading {detail.Url}");
+
+                    var download = await client.DownloadNativeSubAgentArtifactAsync(detail, destination);
+                    if (args.Verbose)
+                        ConsoleOutput.WriteDim($"  Verified {download.Digest} ({FormatSize(download.SizeBytes)})");
+                }
+
+                File.Move(tempPath, destinationPath, overwrite: true);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+
+            ConsoleOutput.WriteSuccess($"Downloaded sub-agent {name}@{version} to {destinationPath}");
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConsoleOutput.HandleHttpError(ex);
+        }
+        catch (InvalidDataException ex)
+        {
+            ConsoleOutput.WriteError($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+    };
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: skillserver download-subagent <name> <version> <path> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Download a sub-agent artifact through the native manifest and verify its digest.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <name>      Sub-agent name");
+        Console.WriteLine("  <version>   Sub-agent version");
+        Console.WriteLine("  <path>      Caller-controlled destination path");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --force, -f   Overwrite the destination path if it exists");
+        Console.WriteLine("  --dry-run     Show what would be downloaded without writing a file");
+        Console.WriteLine("  --verbose, -v Show download URL and verified digest");
+    }
+}

--- a/src/Netclaw.SkillServer.Cli/Commands/LintCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/LintCommand.cs
@@ -24,6 +24,12 @@ internal static class LintCommand
 {
     public static async Task<int> ExecuteAsync(ParsedArgs args)
     {
+        if (args.Positional.Count > 0 &&
+            args.Positional[0].Equals("subagent", StringComparison.OrdinalIgnoreCase))
+        {
+            return ExecuteSubAgentLint(args);
+        }
+
         if (args.Help || args.Positional.Count == 0)
         {
             PrintHelp();
@@ -105,6 +111,38 @@ internal static class LintCommand
         }
 
         return hasErrors ? 1 : 0;
+    }
+
+    private static int ExecuteSubAgentLint(ParsedArgs args)
+    {
+        if (args.Help || args.Positional.Count < 2)
+        {
+            PrintSubAgentHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        var path = args.Positional[1];
+        var result = SubAgentFileScanner.ValidateFile(path);
+
+        ConsoleOutput.WriteInfo($"Linting sub-agent '{path}'...");
+        Console.WriteLine();
+
+        foreach (var issue in result.Issues)
+            ConsoleOutput.WriteError($"✗ {issue}");
+
+        foreach (var warning in result.Warnings)
+            ConsoleOutput.WriteWarning($"⚠ {warning}");
+
+        Console.WriteLine();
+
+        if (result.Issues.Count == 0)
+        {
+            ConsoleOutput.WriteSuccess($"Sub-agent valid ({result.Warnings.Count} warning(s))");
+            return 0;
+        }
+
+        ConsoleOutput.WriteError($"{result.Issues.Count} error(s), {result.Warnings.Count} warning(s) — lint failed");
+        return 1;
     }
 
     /// <summary>
@@ -206,5 +244,22 @@ internal static class LintCommand
         Console.WriteLine("  - Name format (lowercase alphanumeric with hyphens)");
         Console.WriteLine("  - Semantic version format");
         Console.WriteLine("  - Description present (warning if missing)");
+    }
+
+    private static void PrintSubAgentHelp()
+    {
+        Console.WriteLine("Usage: skillserver lint subagent <path>");
+        Console.WriteLine();
+        Console.WriteLine("Validate a NetClaw-compatible sub-agent markdown file.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <path>    Path to agent.md or another .md sub-agent definition");
+        Console.WriteLine();
+        Console.WriteLine("Validates:");
+        Console.WriteLine("  - YAML frontmatter exists");
+        Console.WriteLine("  - Required 'name' and 'description' fields are present");
+        Console.WriteLine("  - Name format matches SkillServer resource names");
+        Console.WriteLine("  - Prompt body is not empty");
+        Console.WriteLine("  - modelRole, visibility, timeoutSeconds, and prefillTimeoutSeconds values are valid");
     }
 }

--- a/src/Netclaw.SkillServer.Cli/Commands/PublishSubAgentCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/PublishSubAgentCommand.cs
@@ -1,0 +1,123 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishSubAgentCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Output;
+using Netclaw.SkillServer.Cli.Publishing;
+
+namespace Netclaw.SkillServer.Cli.Commands;
+
+internal static class PublishSubAgentCommand
+{
+    public static async Task<int> ExecuteAsync(ParsedArgs args, SkillServerClient client)
+    {
+        if (args.Help || args.Positional.Count == 0)
+        {
+            PrintHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        if (!SubAgentFileScanner.IsValidVersion(args.VersionOverride))
+        {
+            ConsoleOutput.WriteError("Error: --version <version> is required for sub-agent publication.");
+            return 1;
+        }
+
+        var result = SubAgentFileScanner.ValidateFile(args.Positional[0]);
+        foreach (var warning in result.Warnings)
+            ConsoleOutput.WriteWarning($"Warning: {warning}");
+
+        if (result.Issues.Count > 0)
+        {
+            foreach (var issue in result.Issues)
+                ConsoleOutput.WriteError($"Error: {issue}");
+            return 1;
+        }
+
+        var subAgent = result.SubAgent!;
+        var version = args.VersionOverride!;
+
+        if (args.DryRun)
+        {
+            ConsoleOutput.WriteWarning(
+                $"Dry run: would publish sub-agent {subAgent.Name}@{version} from {subAgent.FilePath}");
+            return 0;
+        }
+
+        ConsoleOutput.WriteInfo($"Publishing sub-agent {subAgent.Name}@{version}...");
+
+        if (args.Force)
+        {
+            await DeleteExistingAsync(client, subAgent.Name, version, args.Verbose);
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(subAgent.FilePath);
+            if (args.Verbose)
+                ConsoleOutput.WriteDim($"  Uploading agent.md ({FormatSize(stream.Length)})");
+
+            var response = await client.UploadSubAgentIfNotExistsAsync(subAgent.Name, version, stream);
+            if (response is null)
+            {
+                ConsoleOutput.WriteWarning($"Skipped sub-agent {subAgent.Name}@{version} (Already published)");
+                return 0;
+            }
+
+            ConsoleOutput.WriteSuccess($"Published sub-agent {response.Name}@{response.Version}");
+            ConsoleOutput.WriteDim($"  {response.Sha256}");
+            ConsoleOutput.WriteDim($"  {response.Url}");
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConsoleOutput.HandleHttpError(ex);
+        }
+    }
+
+    private static async Task DeleteExistingAsync(
+        SkillServerClient client,
+        string name,
+        string version,
+        bool verbose)
+    {
+        try
+        {
+            await client.DeleteSubAgentVersionAsync(name, version);
+            if (verbose)
+                ConsoleOutput.WriteDim($"  Deleted existing sub-agent {name}@{version}");
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            if (verbose)
+                ConsoleOutput.WriteDim($"  No existing sub-agent version to delete for {name}@{version}");
+        }
+    }
+
+    private static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+    };
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: skillserver publish-subagent <path> --version <version> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Publish a single NetClaw-compatible sub-agent markdown file to the server.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <path>                Path to agent.md or another .md sub-agent definition");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --version <version>   SkillServer publication version (required)");
+        Console.WriteLine("  --force, -f           Delete existing version before re-publishing");
+        Console.WriteLine("  --dry-run             Validate and show what would be published without uploading");
+        Console.WriteLine("  --verbose, -v         Show detailed upload progress");
+    }
+}

--- a/src/Netclaw.SkillServer.Cli/Program.cs
+++ b/src/Netclaw.SkillServer.Cli/Program.cs
@@ -53,7 +53,7 @@ if (parsedArgs.Help)
 var resolver = new ConfigResolver();
 var config = resolver.Resolve(parsedArgs.ServerUrl, parsedArgs.ApiKey);
 
-var requiresAuth = parsedArgs.Command is not "list" and not "versions" and not "verify";
+var requiresAuth = parsedArgs.Command is not "list" and not "versions" and not "verify" and not "download-subagent";
 
 if (!config.HasServerUrl)
 {
@@ -77,6 +77,8 @@ static async Task<int> DispatchAsync(ParsedArgs parsedArgs, SkillServerClient cl
     parsedArgs.Command switch
     {
         "publish" => await PublishCommand.ExecuteAsync(parsedArgs, client),
+        "publish-subagent" => await PublishSubAgentCommand.ExecuteAsync(parsedArgs, client),
+        "download-subagent" => await DownloadSubAgentCommand.ExecuteAsync(parsedArgs, client),
         "publish-all" => await PublishAllCommand.ExecuteAsync(parsedArgs, client),
         "delete" => await DeleteCommand.ExecuteAsync(parsedArgs, client),
         "list" => await ListCommand.ExecuteAsync(parsedArgs, client),
@@ -118,8 +120,10 @@ static void PrintHelp()
     Console.WriteLine();
     Console.WriteLine("Commands:");
     Console.WriteLine("  publish <path>            Publish a skill directory to the server");
+    Console.WriteLine("  publish-subagent <path>   Publish a sub-agent markdown file to the server");
+    Console.WriteLine("  download-subagent <n> <v> <path> Download a verified sub-agent artifact");
     Console.WriteLine("  publish-all <path>        Batch-publish all skills in a directory");
-    Console.WriteLine("  lint <path>               Validate skills against spec (no auth required)");
+    Console.WriteLine("  lint <path>               Validate skills or sub-agents (no auth required)");
     Console.WriteLine("  delete <name> <version>   Delete a published skill version");
     Console.WriteLine("  list                      List skills on the server");
     Console.WriteLine("  versions <name>           List all versions of a skill");

--- a/src/Netclaw.SkillServer.Cli/Publishing/SubAgentFileScanner.cs
+++ b/src/Netclaw.SkillServer.Cli/Publishing/SubAgentFileScanner.cs
@@ -1,0 +1,258 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubAgentFileScanner.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace Netclaw.SkillServer.Cli.Publishing;
+
+internal sealed record ScannedSubAgent(
+    string FilePath,
+    string Name,
+    string Description,
+    string Body,
+    string ModelRole,
+    int TimeoutSeconds,
+    int? PrefillTimeoutSeconds,
+    string Visibility,
+    bool EmitStructuredFindings);
+
+internal sealed record SubAgentLintResult(
+    IReadOnlyList<string> Issues,
+    IReadOnlyList<string> Warnings,
+    ScannedSubAgent? SubAgent);
+
+internal static partial class SubAgentFileScanner
+{
+    private static readonly HashSet<string> KnownFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "name",
+        "description",
+        "tools",
+        "modelRole",
+        "timeoutSeconds",
+        "prefillTimeoutSeconds",
+        "visibility",
+        "emitStructuredFindings"
+    };
+
+    public static SubAgentLintResult ValidateFile(string filePath)
+    {
+        var path = Path.GetFullPath(filePath);
+        var displayName = Path.GetFileName(path);
+
+        if (!File.Exists(path))
+        {
+            return new SubAgentLintResult(
+                [$"{displayName}: File does not exist"],
+                [],
+                null);
+        }
+
+        if (!path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            return new SubAgentLintResult(
+                [$"{displayName}: Sub-agent definition must be a markdown file"],
+                [],
+                null);
+        }
+
+        var content = File.ReadAllText(path);
+        return ValidateContent(displayName, path, content);
+    }
+
+    internal static SubAgentLintResult ValidateContent(string displayName, string filePath, string content)
+    {
+        var issues = new List<string>();
+        var warnings = new List<string>();
+        var match = FrontmatterRegex().Match(content);
+
+        if (!match.Success)
+        {
+            issues.Add($"{displayName}: Missing or invalid YAML frontmatter");
+            return new SubAgentLintResult(issues, warnings, null);
+        }
+
+        var fields = ParseFrontmatter(match.Groups[1].Value, warnings, displayName);
+        var body = match.Groups[2].Value.Trim();
+
+        var name = fields.GetValueOrDefault("name");
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            issues.Add($"{displayName}: Missing required 'name' field in frontmatter");
+        }
+        else if (!ValidNameRegex().IsMatch(name) || name.Length > 64)
+        {
+            issues.Add($"{displayName}: Invalid 'name' format '{name}' - must be 1-64 lowercase alphanumeric characters and hyphens, with no leading, trailing, or consecutive hyphens");
+        }
+
+        var description = fields.GetValueOrDefault("description");
+        if (string.IsNullOrWhiteSpace(description))
+            issues.Add($"{displayName}: Missing required 'description' field in frontmatter");
+
+        if (string.IsNullOrWhiteSpace(body))
+            issues.Add($"{displayName}: Sub-agent prompt body must not be empty");
+
+        var modelRole = NormalizeModelRole(fields.GetValueOrDefault("modelRole"), issues, displayName);
+        var visibility = NormalizeVisibility(fields.GetValueOrDefault("visibility"), issues, displayName);
+        var timeoutSeconds = ParseTimeout(fields.GetValueOrDefault("timeoutSeconds"), "timeoutSeconds", 60, 5, 600, issues, displayName);
+        var prefillTimeoutSeconds = ParseOptionalTimeout(fields.GetValueOrDefault("prefillTimeoutSeconds"), "prefillTimeoutSeconds", 5, 3600, issues, displayName);
+        var emitStructuredFindings = ParseBool(fields.GetValueOrDefault("emitStructuredFindings"), "emitStructuredFindings", false, issues, displayName);
+
+        if (issues.Count > 0)
+            return new SubAgentLintResult(issues, warnings, null);
+
+        return new SubAgentLintResult(
+            issues,
+            warnings,
+            new ScannedSubAgent(
+                Path.GetFullPath(filePath),
+                name!,
+                description!,
+                body,
+                modelRole,
+                timeoutSeconds,
+                prefillTimeoutSeconds,
+                visibility,
+                emitStructuredFindings));
+    }
+
+    private static Dictionary<string, string> ParseFrontmatter(string yaml, List<string> warnings, string displayName)
+    {
+        var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawLine in yaml.Split('\n', StringSplitOptions.TrimEntries))
+        {
+            if (string.IsNullOrWhiteSpace(rawLine) || rawLine.StartsWith('#') || rawLine.StartsWith('-'))
+                continue;
+
+            var colonIndex = rawLine.IndexOf(':');
+            if (colonIndex <= 0)
+                continue;
+
+            var key = rawLine[..colonIndex].Trim();
+            var value = rawLine[(colonIndex + 1)..].Trim();
+            if (value.Length >= 2 &&
+                ((value[0] == '"' && value[^1] == '"') ||
+                 (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value[1..^1];
+            }
+
+            if (!KnownFields.Contains(key))
+                warnings.Add($"{displayName}: Unknown frontmatter field '{key}' will be ignored by SkillServer");
+
+            fields[key] = value;
+        }
+
+        return fields;
+    }
+
+    private static string NormalizeModelRole(string? value, List<string> issues, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Equals("Compaction", StringComparison.OrdinalIgnoreCase))
+            return "Compaction";
+
+        if (value.Equals("Main", StringComparison.OrdinalIgnoreCase))
+            return "Main";
+
+        issues.Add($"{displayName}: Invalid modelRole. Must be 'Compaction' or 'Main'");
+        return "";
+    }
+
+    private static string NormalizeVisibility(string? value, List<string> issues, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Equals("user-facing", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("UserFacing", StringComparison.OrdinalIgnoreCase))
+        {
+            return "user-facing";
+        }
+
+        if (value.Equals("internal", StringComparison.OrdinalIgnoreCase))
+            return "internal";
+
+        issues.Add($"{displayName}: Invalid visibility. Must be 'user-facing' or 'internal'");
+        return "";
+    }
+
+    private static int ParseTimeout(
+        string? value,
+        string fieldName,
+        int defaultValue,
+        int min,
+        int max,
+        List<string> issues,
+        string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return defaultValue;
+
+        if (!int.TryParse(value, out var parsed) || parsed < min || parsed > max)
+        {
+            issues.Add($"{displayName}: Invalid {fieldName}. Must be between {min} and {max}");
+            return defaultValue;
+        }
+
+        return parsed;
+    }
+
+    private static int? ParseOptionalTimeout(
+        string? value,
+        string fieldName,
+        int min,
+        int max,
+        List<string> issues,
+        string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (!int.TryParse(value, out var parsed) || parsed < min || parsed > max)
+        {
+            issues.Add($"{displayName}: Invalid {fieldName}. Must be between {min} and {max}");
+            return null;
+        }
+
+        return parsed;
+    }
+
+    private static bool ParseBool(
+        string? value,
+        string fieldName,
+        bool defaultValue,
+        List<string> issues,
+        string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return defaultValue;
+
+        if (bool.TryParse(value, out var parsed))
+            return parsed;
+
+        issues.Add($"{displayName}: Invalid {fieldName}. Must be 'true' or 'false'");
+        return defaultValue;
+    }
+
+    internal static bool IsValidVersion(string? version)
+    {
+        return !string.IsNullOrWhiteSpace(version) &&
+               version.Length <= 64 &&
+               version.All(c => char.IsLetterOrDigit(c) || c == '.' || c == '-' || c == '+');
+    }
+
+    internal static bool IsValidName(string? name)
+    {
+        return !string.IsNullOrWhiteSpace(name) &&
+               name.Length <= 64 &&
+               ValidNameRegex().IsMatch(name);
+    }
+
+    [GeneratedRegex(@"^---\s*\r?\n(.*?)\r?\n---\s*(?:\r?\n)?(.*)$", RegexOptions.Singleline)]
+    private static partial Regex FrontmatterRegex();
+
+    [GeneratedRegex(@"^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.Compiled)]
+    private static partial Regex ValidNameRegex();
+}

--- a/src/Netclaw.SkillServer.Cli/README.md
+++ b/src/Netclaw.SkillServer.Cli/README.md
@@ -70,6 +70,21 @@ skillserver publish-all ./skills
 
 # Dry run
 skillserver publish-all ./skills --dry-run
+
+# Validate a sub-agent markdown file
+skillserver lint subagent ./agents/support-agent.md
+
+# Publish a sub-agent (version is a SkillServer packaging value)
+skillserver publish-subagent ./agents/support-agent.md --version 1.0.0
+
+# Re-publish a sub-agent if the version already exists
+skillserver publish-subagent ./agents/support-agent.md --version 1.0.0 --force
+
+# Dry run without uploading
+skillserver publish-subagent ./agents/support-agent.md --version 1.0.0 --dry-run
+
+# Download and verify a sub-agent to a caller-chosen path
+skillserver download-subagent support-agent 1.0.0 ./staging/support-agent.md
 ```
 
 ### Listing and Search
@@ -94,6 +109,29 @@ skillserver list --output json
 # Verify local files match the published version
 skillserver verify ./my-skill
 ```
+
+### Sub-Agent Files
+
+Sub-agent files are single markdown files with YAML frontmatter and a prompt body.
+
+```markdown
+---
+name: support-agent
+description: Diagnose support issues and identify missing evidence.
+modelRole: Main
+timeoutSeconds: 120
+visibility: internal
+emitStructuredFindings: true
+---
+
+You are a support diagnostician.
+```
+
+The CLI validates the same required fields and value ranges as the server. The publication version is supplied with `--version` because local NetClaw sub-agent files do not require version metadata.
+
+### Sync Primitives
+
+The CLI and client library keep artifact sync destination-agnostic. SkillServer publishes verified `agent-md` artifacts; adapters for NetClaw, OpenCode, or other clients choose their own managed destination and format conversion policy. `download-subagent` writes only to the path you provide, verifies the manifest digest before moving the staged file into place, and refuses to overwrite existing files unless `--force` is set. Generic sync tooling should download and verify artifacts first, then hand the staged bytes to a target-specific adapter rather than hard-coding local application paths into the protocol.
 
 ### Deleting
 

--- a/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
@@ -79,6 +79,44 @@ public sealed class CliArgsParserTests
     }
 
     [Fact]
+    public void Parse_PublishSubAgentCommand_WithAllFlags()
+    {
+        var result = CliArgsParser.Parse([
+            "publish-subagent", "./agents/support-agent.md",
+            "--version", "1.0.0",
+            "--force",
+            "--dry-run",
+            "--verbose"
+        ]);
+
+        Assert.Equal("publish-subagent", result.Command);
+        Assert.Equal("./agents/support-agent.md", result.Positional[0]);
+        Assert.Equal("1.0.0", result.VersionOverride);
+        Assert.True(result.Force);
+        Assert.True(result.DryRun);
+        Assert.True(result.Verbose);
+    }
+
+    [Fact]
+    public void Parse_DownloadSubAgentCommand_WithFlags()
+    {
+        var result = CliArgsParser.Parse([
+            "download-subagent", "support-agent", "1.0.0", "./staging/support-agent.md",
+            "--force",
+            "--dry-run",
+            "--verbose"
+        ]);
+
+        Assert.Equal("download-subagent", result.Command);
+        Assert.Equal("support-agent", result.Positional[0]);
+        Assert.Equal("1.0.0", result.Positional[1]);
+        Assert.Equal("./staging/support-agent.md", result.Positional[2]);
+        Assert.True(result.Force);
+        Assert.True(result.DryRun);
+        Assert.True(result.Verbose);
+    }
+
+    [Fact]
     public void Parse_ListCommand_WithSearch()
     {
         var result = CliArgsParser.Parse(["list", "--search", "akka", "--take", "10"]);

--- a/tests/Netclaw.SkillServer.Cli.Tests/DownloadSubAgentCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/DownloadSubAgentCommandTests.cs
@@ -1,0 +1,178 @@
+// -----------------------------------------------------------------------
+// <copyright file="DownloadSubAgentCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Commands;
+using Xunit;
+
+namespace Netclaw.SkillServer.Cli.Tests;
+
+public sealed class DownloadSubAgentCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DownloadSubAgentCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"skillserver-subagent-download-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DownloadsVerifiedArtifactToDestination()
+    {
+        var agentMd = "---\nname: support-agent\ndescription: test\n---\nPrompt body.";
+        var digest = ComputeSha256Digest(agentMd);
+        var handler = new RecordingHandler(
+            JsonResponse(CreateDetail(digest)),
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(agentMd, Encoding.UTF8, "text/markdown")
+            });
+        using var client = CreateClient(handler);
+        var destination = Path.Combine(_tempDir, "support-agent.md");
+
+        var exitCode = await DownloadSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["support-agent", "1.0.0", destination], Verbose = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(agentMd, await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken));
+        Assert.Equal("/manifest/subagents/support-agent/versions/1.0.0.json", handler.Requests[0].Path);
+        Assert.Equal("/subagents/support-agent/1.0.0/agent.md", handler.Requests[1].Path);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExistingDestinationWithoutForce_DoesNotCallServer()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        var destination = Path.Combine(_tempDir, "support-agent.md");
+        await File.WriteAllTextAsync(destination, "existing", TestContext.Current.CancellationToken);
+
+        var exitCode = await DownloadSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["support-agent", "1.0.0", destination] },
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(handler.Requests);
+        Assert.Equal("existing", await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DryRun_DoesNotCallServerOrWriteFile()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        var destination = Path.Combine(_tempDir, "support-agent.md");
+
+        var exitCode = await DownloadSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["support-agent", "1.0.0", destination], DryRun = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(handler.Requests);
+        Assert.False(File.Exists(destination));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DigestMismatch_DoesNotLeaveDestinationFile()
+    {
+        var handler = new RecordingHandler(
+            JsonResponse(CreateDetail("sha256:0000000000000000000000000000000000000000000000000000000000000000")),
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("wrong bytes", Encoding.UTF8, "text/markdown")
+            });
+        using var client = CreateClient(handler);
+        var destination = Path.Combine(_tempDir, "support-agent.md");
+
+        var exitCode = await DownloadSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["support-agent", "1.0.0", destination] },
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(destination));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp-*"));
+    }
+
+    private static NativeSubAgentVersionDetail CreateDetail(string digest) => new()
+    {
+        Kind = "subagent-version",
+        Name = "support-agent",
+        Version = "1.0.0",
+        Type = SubAgentArtifactTypes.AgentMd,
+        Description = "test",
+        Url = "/subagents/support-agent/1.0.0/agent.md",
+        Digest = digest,
+        Links = new NativeManifestSelfLinks
+        {
+            Self = new NativeManifestLink
+            {
+                Href = "/manifest/subagents/support-agent/versions/1.0.0.json"
+            }
+        }
+    };
+
+    private static SkillServerClient CreateClient(HttpMessageHandler handler)
+    {
+        return new SkillServerClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.test/")
+        });
+    }
+
+    private static HttpResponseMessage JsonResponse(NativeSubAgentVersionDetail detail)
+    {
+        var json = JsonSerializer.Serialize(detail, SkillServerClientJsonContext.Default.NativeSubAgentVersionDetail);
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static string ComputeSha256Digest(string content)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri?.AbsolutePath ?? ""));
+
+            return Task.FromResult(_responses.Count == 0
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : _responses.Dequeue());
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Path);
+}

--- a/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
@@ -44,6 +44,27 @@ public sealed class ProgramDispatchTests : IDisposable
     }
 
     [Fact]
+    public async Task LintSubAgent_DoesNotRequireServerUrl()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var agentPath = Path.Combine(_tempDir, "support-agent.md");
+        await File.WriteAllTextAsync(agentPath, """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            ---
+
+            You are a support diagnostician.
+            """, ct);
+
+        var result = await RunCliAsync(["lint", "subagent", agentPath], ct);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Server URL not configured", result.StdErr);
+        Assert.DoesNotContain("Server URL not configured", result.StdOut);
+    }
+
+    [Fact]
     public async Task List_RequiresServerUrl()
     {
         var ct = TestContext.Current.CancellationToken;

--- a/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentCommandTests.cs
@@ -1,0 +1,193 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishSubAgentCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Commands;
+using Xunit;
+
+namespace Netclaw.SkillServer.Cli.Tests;
+
+public sealed class PublishSubAgentCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PublishSubAgentCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"skillserver-subagent-publish-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidFile_PostsSubAgent()
+    {
+        var handler = new RecordingHandler(JsonResponse(new SubAgentUploadResponse
+        {
+            Name = "support-agent",
+            Version = "1.0.0",
+            Sha256 = "sha256:abc",
+            Url = "https://example.test/subagents/support-agent/1.0.0/agent.md"
+        }));
+        using var client = CreateClient(handler);
+        var path = CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [path], VersionOverride = "1.0.0", Verbose = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/subagents", request.Path);
+        Assert.Contains("support-agent", request.Body);
+        Assert.Contains("1.0.0", request.Body);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DuplicateVersion_ReturnsSuccessWithoutThrowing()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.Conflict));
+        using var client = CreateClient(handler);
+        var path = CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [path], VersionOverride = "1.0.0" },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Force_DeletesBeforeUpload()
+    {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.NoContent),
+            JsonResponse(new SubAgentUploadResponse
+            {
+                Name = "support-agent",
+                Version = "1.0.0",
+                Sha256 = "sha256:abc",
+                Url = "https://example.test/subagents/support-agent/1.0.0/agent.md"
+            }));
+        using var client = CreateClient(handler);
+        var path = CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [path], VersionOverride = "1.0.0", Force = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(HttpMethod.Delete, handler.Requests[0].Method);
+        Assert.Equal("/subagents/support-agent/1.0.0", handler.Requests[0].Path);
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Equal("/subagents", handler.Requests[1].Path);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DryRun_DoesNotCallServer()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        var path = CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [path], VersionOverride = "1.0.0", DryRun = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingVersion_ReturnsError()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        var path = CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [path] },
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    private string CreateSubAgentFile(string name)
+    {
+        var path = Path.Combine(_tempDir, $"{name}.md");
+        File.WriteAllText(path, $"""
+            ---
+            name: {name}
+            description: Diagnose support issues.
+            modelRole: Main
+            timeoutSeconds: 120
+            visibility: internal
+            ---
+
+            You are a support diagnostician.
+            """);
+        return path;
+    }
+
+    private static SkillServerClient CreateClient(HttpMessageHandler handler)
+    {
+        return new SkillServerClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.test/")
+        });
+    }
+
+    private static HttpResponseMessage JsonResponse(SubAgentUploadResponse response)
+    {
+        var json = JsonSerializer.Serialize(response, SkillServerClientJsonContext.Default.SubAgentUploadResponse);
+        return new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri?.AbsolutePath ?? "",
+                body));
+
+            return _responses.Count == 0
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : _responses.Dequeue();
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Path, string Body);
+}

--- a/tests/Netclaw.SkillServer.Cli.Tests/SubAgentFileScannerTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/SubAgentFileScannerTests.cs
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubAgentFileScannerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Netclaw.SkillServer.Cli.Publishing;
+using Xunit;
+
+namespace Netclaw.SkillServer.Cli.Tests;
+
+public sealed class SubAgentFileScannerTests
+{
+    [Fact]
+    public void ValidateContent_ValidSubAgent_ReturnsScannedSubAgent()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            modelRole: Main
+            timeoutSeconds: 120
+            prefillTimeoutSeconds: 30
+            visibility: internal
+            emitStructuredFindings: true
+            ---
+
+            You are a support diagnostician.
+            """);
+
+        Assert.Empty(result.Issues);
+        Assert.Empty(result.Warnings);
+        Assert.NotNull(result.SubAgent);
+        Assert.Equal("support-agent", result.SubAgent.Name);
+        Assert.Equal("Main", result.SubAgent.ModelRole);
+        Assert.Equal(120, result.SubAgent.TimeoutSeconds);
+        Assert.Equal(30, result.SubAgent.PrefillTimeoutSeconds);
+        Assert.Equal("internal", result.SubAgent.Visibility);
+        Assert.True(result.SubAgent.EmitStructuredFindings);
+    }
+
+    [Fact]
+    public void ValidateContent_DefaultOptionalFields_MatchesServerDefaults()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Empty(result.Issues);
+        Assert.NotNull(result.SubAgent);
+        Assert.Equal("Compaction", result.SubAgent.ModelRole);
+        Assert.Equal(60, result.SubAgent.TimeoutSeconds);
+        Assert.Null(result.SubAgent.PrefillTimeoutSeconds);
+        Assert.Equal("user-facing", result.SubAgent.Visibility);
+        Assert.False(result.SubAgent.EmitStructuredFindings);
+    }
+
+    [Theory]
+    [InlineData("", "Missing required 'name'")]
+    [InlineData("-bad", "Invalid 'name' format")]
+    [InlineData("bad--name", "Invalid 'name' format")]
+    public void ValidateContent_InvalidNames_ReportIssue(string name, string expected)
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", $"""
+            ---
+            name: {name}
+            description: Diagnose support issues.
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Contains(result.Issues, issue => issue.Contains(expected, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateContent_InvalidOptionalValues_ReportIssues()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            modelRole: Worker
+            timeoutSeconds: 2
+            prefillTimeoutSeconds: 9999
+            visibility: public
+            emitStructuredFindings: sometimes
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid modelRole", StringComparison.Ordinal));
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid timeoutSeconds", StringComparison.Ordinal));
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid prefillTimeoutSeconds", StringComparison.Ordinal));
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid visibility", StringComparison.Ordinal));
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid emitStructuredFindings", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateContent_UnknownField_WarnsOnly()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            customField: value
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Empty(result.Issues);
+        Assert.Single(result.Warnings);
+        Assert.Contains("customField", result.Warnings[0]);
+    }
+
+    [Fact]
+    public void ValidateContent_EmptyBody_ReportIssue()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            ---
+            """);
+
+        Assert.Contains(result.Issues, issue => issue.Contains("prompt body", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Closes #91

## Summary
- add lint subagent validation for NetClaw-compatible agent markdown files
- add publish-subagent with required packaging version, duplicate skip, force, dry-run, and verbose output
- add download-subagent as a destination-agnostic verified artifact sync primitive
- document sub-agent CLI workflows and adapter-owned destinations

## Tests
- dotnet build -c Release
- dotnet test -c Release
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- dotnet slopwatch analyze
- git diff --check