### PR TITLE
Pin Microsoft.OpenApi to patched version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,15 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <AspireVersion>13.1.2</AspireVersion>
   </PropertyGroup>
 
   <!-- ASP.NET Core Dependencies -->
   <ItemGroup Label="ASP.NET Core">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <!-- Pin to patched version to avoid CVE-2026-49451 (stack overflow on circular schema refs). -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- enables central transitive package pinning
- pins transitive `Microsoft.OpenApi` to `2.7.5` to avoid CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc

## Validation
- `dotnet test -c Release SkillServer.slnx`
- `dotnet build -c Release`

## Notes
- This is a clean dependency-only PR.
- Unblocks CI on netclaw-dev/skill-server#103, which currently fails restore with NU1903 from `Microsoft.OpenApi 2.0.0`.