### PR TITLE
Release 0.4.0-beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,12 +20,31 @@
   </PropertyGroup>
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <PackageReleaseNotes>**New Features**
-- Add `lint` command to CLI — validates local skills against the AgentSkills.io spec without requiring a server connection (#68)
+- Add native manifest endpoints (`/manifest.json` and linked skill identity/version documents) for destination-agnostic, RFC-compatible sync (#96)
+- Add first-class sub-agent support — `/subagents` storage with upload, list, delete, and `agent.md` download endpoints, and NetClaw sub-agent markdown frontmatter validation (#97)
+- Add native sub-agent manifest endpoints (`/manifest/subagents/...`) that traverse from the root native manifest alongside skills (#98)
+- Add sub-agent support to `Netclaw.SkillClient` — upload, list, download, delete, and native manifest traversal helpers (#99)
+- Add CLI sub-agent commands: `lint subagent`, `publish-subagent`, and `download-subagent` for validating, publishing, and syncing sub-agents from the command line (#100)
+- Add deterministic `archive.zip` downloads for resourceful skills, backfilled for existing skill versions (#95)
 
-**Bug Fixes**
-- Fix unbound variable error in `install-skillserver.sh` — resolves installation failures on strict Bash environments (#60)</PackageReleaseNotes>
+**Improvements**
+- Preserve executable permission bits (Unix mode) for skill resources — packaged helper scripts in downloaded archives no longer need a manual `chmod` (#103)
+
+**CI/CD**
+- Skip the Docker `latest` tag and mark GitHub releases as prerelease automatically when publishing a prerelease tag (#101)
+
+**Security**
+- Resolve CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc by pinning the transitive `Microsoft.OpenApi` dependency to 2.7.5 (#104)
+- Resolve GHSA-hv8m-jj95-wg3x (MessagePack/StreamJsonRpc LZ4 decompression DoS) by upgrading MessagePack from 2.5.301 to 3.1.7 (#76, #80)
+- Suppress GHSA-2m69-gcr7-jv3q (SQLitePCLRaw) pending an upstream patched release (#76)
+
+**Dependency Updates**
+- Bump Microsoft.Data.Sqlite from 10.0.7 to 10.0.9 (#106)
+- Bump Microsoft.Extensions.Http from 10.0.7 to 10.0.9 (#107)
+- Bump Dapper from 2.1.72 to 2.1.79 (#78)
+- Bump Microsoft.AspNetCore.OpenApi from 10.0.7 to 10.0.9 (#83)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+#### 0.4.0-beta.2 July 3rd 2026 ####
+
+**New Features**
+- Add native manifest endpoints (`/manifest.json` and linked skill identity/version documents) for destination-agnostic, RFC-compatible sync (#96)
+- Add first-class sub-agent support — `/subagents` storage with upload, list, delete, and `agent.md` download endpoints, and NetClaw sub-agent markdown frontmatter validation (#97)
+- Add native sub-agent manifest endpoints (`/manifest/subagents/...`) that traverse from the root native manifest alongside skills (#98)
+- Add sub-agent support to `Netclaw.SkillClient` — upload, list, download, delete, and native manifest traversal helpers (#99)
+- Add CLI sub-agent commands: `lint subagent`, `publish-subagent`, and `download-subagent` for validating, publishing, and syncing sub-agents from the command line (#100)
+- Add deterministic `archive.zip` downloads for resourceful skills, backfilled for existing skill versions (#95)
+
+**Improvements**
+- Preserve executable permission bits (Unix mode) for skill resources — packaged helper scripts in downloaded archives no longer need a manual `chmod` (#103)
+
+**CI/CD**
+- Skip the Docker `latest` tag and mark GitHub releases as prerelease automatically when publishing a prerelease tag (#101)
+
+**Security**
+- Resolve CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc by pinning the transitive `Microsoft.OpenApi` dependency to 2.7.5 (#104)
+- Resolve GHSA-hv8m-jj95-wg3x (MessagePack/StreamJsonRpc LZ4 decompression DoS) by upgrading MessagePack from 2.5.301 to 3.1.7 (#76, #80)
+- Suppress GHSA-2m69-gcr7-jv3q (SQLitePCLRaw) pending an upstream patched release (#76)
+
+**Dependency Updates**
+- Bump Microsoft.Data.Sqlite from 10.0.7 to 10.0.9 (#106)
+- Bump Microsoft.Extensions.Http from 10.0.7 to 10.0.9 (#107)
+- Bump Dapper from 2.1.72 to 2.1.79 (#78)
+- Bump Microsoft.AspNetCore.OpenApi from 10.0.7 to 10.0.9 (#83)
+
 #### 0.3.1 May 15th 2026 ####
 
 **New Features**


### PR DESCRIPTION
## Summary
Prepares the 0.4.0-beta.2 prerelease. This is a catch-up documentation release — the 0.4.0 line (native manifest and sub-agent publishing/sync) was never documented in RELEASE_NOTES.md when 0.4.0-beta.1 was cut, so this entry covers the full 0.4.0 feature set plus what changed since beta.1.

- Add RELEASE_NOTES.md entry for 0.4.0-beta.2 covering native manifest endpoints, sub-agent storage/publishing/sync (CLI `lint subagent`, `publish-subagent`, `download-subagent`), deterministic skill archives, executable resource mode preservation, prerelease publishing guards, security dependency pins, and runtime dependency bumps
- Sync `Directory.Build.props` `VersionPrefix` to `0.4.0` and `PackageReleaseNotes` to match

## Notes
- The published package version is tag-driven (`release.yml` uses `-p:PackageVersion=${github.ref_name}`); `VersionPrefix` here only affects local/unversioned builds.
- No tag is created by this PR. Tagging `0.4.0-beta.2` happens after merge, per the release process.

## Test plan
- [x] `dotnet build -c Release` — succeeds, 0 warnings
- [x] `dotnet test -c Release` — 201/201 passed
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `scripts/Add-FileHeaders.ps1 -Verify` — all files have headers