### PR TITLE
Harden security and compatibility for native sync (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SkillServer implements Agent Skills standards and defines native extensions for 
 | [Skill Packages](docs/specs/skills.md) | How to author and publish AgentSkills.io-compatible SkillServer skills. |
 | [Sub-Agent Packages](docs/specs/subagents.md) | How NetClaw sub-agent definitions are authored and how SkillServer will publish them. |
 | [Native Manifest](docs/specs/native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future native resources. |
+| [Security And Trust Model](docs/specs/security.md) | Trust boundaries, authentication, digest verification, and sync safety for native sync. |
 | [Sub-Agent Sync Epic](docs/epics/subagent-sync.md) | Requirements and proposed GitHub issue breakdown for native manifest and sub-agent sync. |
 
 ## Quick Start

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,3 +9,4 @@ Some documents are target designs for upcoming work. Each spec calls out current
 | [Skill Packages](skills.md) | AgentSkills.io-compatible skill authoring and SkillServer artifact projection. |
 | [Sub-Agent Packages](subagents.md) | NetClaw sub-agent definition format and proposed SkillServer publication model. |
 | [Native Manifest](native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future artifact types. |
+| [Security And Trust Model](security.md) | Trust boundaries, authentication, digest verification, and sync safety for native sync. |

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -264,6 +264,8 @@ Read access may be open for public registries. Private registries may require th
 
 Clients should send configured credentials to both manifest and artifact URLs for the same feed origin.
 
+See the [Security And Trust Model](security.md) for the full trust boundaries, digest-verification requirements, archive-extraction responsibilities, and sync-safety behavior that apply to native sync.
+
 ## Compatibility With The RFC Feed
 
 The RFC feed remains the compatibility contract for generic AgentSkills.io clients.

--- a/docs/specs/security.md
+++ b/docs/specs/security.md
@@ -1,0 +1,90 @@
+# SkillServer Security And Trust Model
+
+Status: current.
+
+This document states the trust assumptions and safety behavior for SkillServer's native sync surface: the native manifest, skill archive artifacts, and sub-agent definitions. It is a threat model, not a vulnerability-disclosure policy.
+
+## Scope
+
+- Native manifest traversal (`/manifest.json` and linked documents).
+- Skill artifacts (`skill-md` and `archive`) and their downloads.
+- Sub-agent `agent-md` artifacts and their distribution.
+- The `Netclaw.SkillClient` verified-download primitives and CLI sync commands.
+
+Out of scope: how a consuming runtime executes synced content, and the local filesystem layout each client chooses.
+
+## Trust Boundaries
+
+| Boundary | Trusted party | Threat if violated |
+|----------|---------------|--------------------|
+| Client → server writes | Holders of a valid API key | Unauthorized publication or deletion of skills/sub-agents. |
+| Server → client reads | The registry origin | Tampered or substituted artifact bytes. |
+| Artifact author → consumer | Whoever can publish to the feed | Malicious skill scripts or sub-agent prompts distributed to every consumer. |
+| Consumer runtime → host | The consuming client/agent | Unsafe archive extraction or execution of untrusted resources. |
+
+The central assumption: **publishing to a feed is equivalent to influencing the behavior of every consumer that syncs it.** A registry's write access must be guarded accordingly.
+
+## Authentication And Authorization
+
+- Authentication uses a bearer API key (`Authorization: Bearer <key>`). Keys are stored SHA-256 hashed.
+- Enforcement is a single endpoint filter applied only to **write** endpoints: `POST /skills`, `DELETE /skills/{name}/{version}`, `POST /subagents`, `DELETE /subagents/{name}/{version}`, and `/api-keys`.
+- Missing/empty/wrong-scheme credentials return **401**; a well-formed but invalid or expired key returns **403**.
+- When no keys are configured, authentication is disabled and the server is fully open. This is intended only for private/trusted-network deployments; a public registry must configure at least one key.
+- **Reads are open by default**: the manifest, RFC index, and all artifact endpoints (`SKILL.md`, `archive.zip`, per-file resources, `agent.md`, blobs) do not require a key even while write authentication is enabled. A private registry that must gate reads should place SkillServer behind a network boundary or an authenticating proxy; clients send configured credentials to both manifest and artifact URLs for the same origin.
+
+## Integrity: Digest Verification
+
+- Every artifact in the RFC feed and native manifest carries a `sha256:{hex}` digest of the exact bytes at its `url`.
+- Clients **must** verify the digest before installing an artifact. `Netclaw.SkillClient` computes the hash while streaming the download and throws `InvalidDataException` on mismatch.
+- The CLI `download-subagent` command stages the download to a temporary file, verifies the digest, and only then moves it into place; it never leaves a partial or unverified file, and refuses to overwrite an existing destination without `--force`.
+- Because blobs are content-addressed by SHA-256, a substituted or corrupted artifact cannot match its advertised digest.
+
+## Path Traversal And Resource Naming
+
+- Resource relative paths are validated on upload and backfill: leading `/`, drive/scheme markers (`:`), NUL bytes, `.`/`..` segments, and bare root filenames are rejected.
+- Resource downloads resolve by **exact stored relative-path equality**, not a filesystem join, so a traversal path simply fails to match and returns 404 rather than escaping the skill's resource set.
+- Skill archives contain only regular-file entries. Symbolic links and reparse points are rejected at publish time and are never emitted into an archive, so the server cannot distribute a link-based escape.
+
+## Archive Extraction Is The Consumer's Responsibility
+
+SkillServer builds archives from validated paths and **never extracts them**. `Netclaw.SkillClient` downloads and verifies archive **bytes only** — it does not unpack them.
+
+Any consumer that extracts `archive.zip` owns the extraction safety and **must**:
+
+- Reject entries whose resolved path escapes the destination directory (zip-slip).
+- Treat archive members as untrusted content, including their preserved Unix permission bits.
+- Apply its own policy for which resources may be marked executable or run.
+
+## Executable Resource Modes
+
+- Unix permission bits are preserved end-to-end (publish → archive → download), masked to standard permission bits (`0`–`511`). Type bits and setuid/setgid/sticky bits are stripped; a mode outside that range is rejected on upload.
+- A synced executable resource therefore runs with the author's intended permissions. Consumers must treat such scripts as untrusted code and gate execution on feed trust.
+
+## Sub-Agent Prompt Distribution
+
+A sub-agent `agent-md` body becomes a **system prompt** inside the consuming runtime. Distributing a sub-agent is distributing executable instructions, and is a prompt-injection vector.
+
+Trust assumptions for consumers:
+
+- Sync sub-agents only from trusted feeds.
+- Keep user-authored local definitions authoritative; server-synced files must never overwrite them.
+- Install server-synced definitions into a managed, clearly-scoped location that can be pruned without touching user files.
+- Review server-synced prompts as you would review third-party code.
+
+## Sync Safety
+
+- **Non-destructive**: a failed sync (network error, digest mismatch) leaves existing local artifacts in place.
+- **Prune-after-confirm**: server-synced artifacts are removed only after a successful collection sync confirms the server no longer advertises them.
+- **User files win**: user-authored local files take precedence over server-synced files with the same identity.
+- **No prescribed paths**: the server protocol carries `name`, `version`, `kind`, `type`, `url`, and `digest`; local filesystem layout is entirely the client's choice.
+
+## Forward Compatibility
+
+Clients must ignore unsupported resource `kind`s, unknown artifact `type`s, and unrecognized fields rather than failing to parse them. This lets a newer server introduce collections or artifact types without breaking older clients, and keeps the RFC skill feed compatible for generic AgentSkills.io consumers.
+
+## Summary Of Trust Assumptions
+
+- The registry operator is trusted to control who can publish and delete.
+- Artifact authors are trusted to the extent the feed's write access is controlled — publishing runs code and prompts on consumers.
+- Transport integrity is enforced by digest verification, not assumed from the network.
+- Consumers are responsible for safe extraction and execution of the verified bytes they receive.

--- a/docs/specs/skills.md
+++ b/docs/specs/skills.md
@@ -115,21 +115,27 @@ The native manifest must reuse this object instead of inventing another skill in
 
 ## Resource Distribution
 
-Target behavior:
+SkillServer projects skills into two artifact shapes:
 
-- Skills with only `SKILL.md` should publish as `type: "skill-md"`.
-- Skills with supporting files should publish as `type: "archive"`.
-- SkillServer standardizes archive artifacts on `.zip` at `/skills/{name}/{version}/archive.zip`.
-- Archive artifacts should contain `SKILL.md` at the archive root plus supporting files under their relative paths.
-- The RFC feed and native manifest should point to the same artifact URL and digest for a given skill version.
-- Archive artifact digest and size metadata must be additive. Existing `SKILL.md` digest behavior must remain available for compatibility with current skill download and verification APIs.
+- Skills with only `SKILL.md` publish as `type: "skill-md"`.
+- Skills with supporting files publish as `type: "archive"`.
+- Archive artifacts are standardized on `.zip` and served at `/skills/{name}/{version}/archive.zip`.
+- Archive artifacts contain `SKILL.md` at the archive root plus supporting files under their relative paths.
+- Archives are deterministic: entries are ordered, timestamps are fixed, and Unix permission bits are preserved (masked to standard permission bits) so an executable resource stays executable after extraction.
+- The RFC feed and native manifest point to the same artifact URL and digest for a given skill version.
+- Archive artifact digest and size metadata are additive. The original `SKILL.md` digest remains available for compatibility with existing skill download and verification APIs.
+- Per-file resource routes at `/skills/{name}/{version}/{path}` remain available for compatibility.
 
-Current implementation gap:
+### Migration For Existing Resourceful Skills
 
-- SkillServer currently stores resource files individually and exposes them through a `resources` extension in the RFC-shaped index.
-- SkillServer has an `archive` type constant but does not currently build or serve skill archives.
+Skills published before archive support existed were stored as individual resource files with only a `skill-md` artifact. SkillServer backfills these automatically; no manual re-publish is required.
 
-The migration path is to add archive artifact support while preserving existing per-file resource routes for compatibility.
+- On startup, a one-time backfill scans versioned skills that have resources but no archive artifact.
+- For each, it builds the deterministic archive from the stored `SKILL.md` and resource blobs, stores it as a content-addressed blob, and records the additive `archive` artifact metadata.
+- The original `SKILL.md` bytes, digest, and per-file resource routes are preserved, so existing RFC feed consumers and `skill-md` download/verification callers are unaffected.
+- Backfill is additive and idempotent: a version that already has an archive artifact is skipped, and a failed backfill leaves the existing `skill-md` artifact and per-file routes intact.
+
+Clients that only understand `skill-md` continue to work; clients that understand archives pick up the archive artifact on their next sync.
 
 ## Validation Requirements
 

--- a/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
+++ b/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClientForwardCompatTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Text;
+using Netclaw.SkillClient;
+using Xunit;
+
+namespace SkillServer.Integration.Tests;
+
+/// <summary>
+/// Forward-compatibility hardening for the native manifest client (issue #93):
+/// a client built against today's schema must tolerate unknown resource kinds,
+/// unknown artifact types, and unrecognized fields that a newer server may emit,
+/// rather than failing to parse them.
+/// </summary>
+public sealed class ClientForwardCompatTests
+{
+    private sealed class CannedJsonHandler(string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private static SkillServerClient CreateClient(string json)
+    {
+        var httpClient = new HttpClient(new CannedJsonHandler(json))
+        {
+            BaseAddress = new Uri("http://localhost/")
+        };
+        return new SkillServerClient(httpClient);
+    }
+
+    [Fact]
+    public async Task GetManifest_WithUnknownLinkAndTopLevelField_IsTolerated()
+    {
+        const string json = """
+            {
+              "$schema": "https://netclaw.dev/manifest/v1",
+              "generatedAt": "2026-07-03T00:00:00Z",
+              "futureTopLevelField": { "anything": [1, 2, 3] },
+              "links": {
+                "self": { "href": "/manifest.json" },
+                "rfcSkills": { "href": "/.well-known/agent-skills/index.json" },
+                "skills": { "href": "/manifest/skills/index.json" },
+                "subagents": { "href": "/manifest/subagents/index.json" },
+                "futureCollection": { "href": "/manifest/future/index.json" }
+              }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var manifest = await client.GetManifestAsync(ct);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("/manifest/skills/index.json", manifest.Links.Skills.Href);
+        Assert.Equal("/manifest/subagents/index.json", manifest.Links.SubAgents.Href);
+    }
+
+    [Fact]
+    public async Task GetNativeSkillPage_WithUnknownKindAndExtraFields_IsTolerated()
+    {
+        const string json = """
+            {
+              "kind": "future-skill-page-kind",
+              "range": "0-1",
+              "unexpectedCollectionField": ["ignore", "me"],
+              "items": [
+                {
+                  "name": "example-skill",
+                  "latestVersion": "1.0.0",
+                  "versionRange": { "min": "1.0.0", "max": "1.0.0", "count": 1 },
+                  "href": "/manifest/skills/example-skill/index.json",
+                  "futureItemField": "ignored"
+                }
+              ],
+              "links": { "self": { "href": "/manifest/skills/pages/0.json" } }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var page = await client.GetNativeSkillPageAsync("manifest/skills/pages/0.json", ct);
+
+        Assert.NotNull(page);
+        // Unknown kind values round-trip as opaque strings instead of failing.
+        Assert.Equal("future-skill-page-kind", page.Kind);
+        var item = Assert.Single(page.Items);
+        Assert.Equal("example-skill", item.Name);
+        Assert.Equal("/manifest/skills/example-skill/index.json", item.Href);
+    }
+
+    [Fact]
+    public async Task GetNativeSkillVersion_WithUnknownArtifactType_IsTolerated()
+    {
+        const string json = """
+            {
+              "kind": "skill-version",
+              "artifact": {
+                "name": "example-skill",
+                "version": "1.0.0",
+                "type": "oci-image",
+                "description": "A future artifact type older clients do not understand.",
+                "url": "/skills/example-skill/1.0.0/artifact.oci",
+                "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "futureArtifactField": 42
+              },
+              "routesToSubagent": null,
+              "links": { "self": { "href": "/manifest/skills/example-skill/versions/1.0.0.json" } }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var detail = await client.GetNativeSkillVersionByHrefAsync(
+            "manifest/skills/example-skill/versions/1.0.0.json", ct);
+
+        Assert.NotNull(detail);
+        // An unrecognized artifact type is surfaced verbatim so a caller can skip
+        // it, rather than causing deserialization to throw.
+        Assert.Equal("oci-image", detail.Artifact.Type);
+        Assert.Null(detail.RoutesToSubagent);
+    }
+}

--- a/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
+++ b/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
@@ -1,0 +1,211 @@
+// -----------------------------------------------------------------------
+// <copyright file="NativeSyncSecurityTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Netclaw.SkillClient;
+using Xunit;
+
+namespace SkillServer.Integration.Tests;
+
+/// <summary>
+/// Security and forward-compatibility hardening for the native manifest and
+/// sub-agent sync surface (issue #93): authentication boundaries on write
+/// endpoints, open read access to manifest/artifact endpoints, path-traversal
+/// rejection on resource downloads, and digest verification on archive downloads.
+/// </summary>
+[Collection("SkillServer")]
+public sealed class NativeSyncSecurityTests
+{
+    private readonly SkillServerFixture _fixture;
+
+    public NativeSyncSecurityTests(SkillServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static MultipartFormDataContent CreateSubAgentUpload(string name, string version)
+    {
+        var agentMd = $"""
+            ---
+            name: {name}
+            description: Native sync security test sub-agent.
+            ---
+
+            You are a native-sync security test sub-agent.
+            """;
+
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent(name), "name" },
+            { new StringContent(version), "version" }
+        };
+
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(agentMd));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        form.Add(fileContent, "file", "agent.md");
+
+        return form;
+    }
+
+    private async Task<string> PublishResourcefulSkillAsync(string skillName, CancellationToken ct)
+    {
+        var skillMd = $"""
+            ---
+            name: {skillName}
+            description: Native sync security test skill.
+            ---
+
+            # Security Test Skill
+
+            See references/guide.md and scripts/setup.sh for details.
+            """;
+
+        using var content = new MultipartFormDataContent
+        {
+            { new StringContent(skillName), "name" },
+            { new StringContent("1.0.0"), "version" }
+        };
+
+        var mdContent = new ByteArrayContent(Encoding.UTF8.GetBytes(skillMd));
+        mdContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content.Add(mdContent, "file", "SKILL.md");
+
+        content.Add(new ByteArrayContent("# Guide"u8.ToArray()), "resources", "references/guide.md");
+
+        var response = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        response.EnsureSuccessStatusCode();
+        return skillName;
+    }
+
+    // ---- Task 4: write endpoints require authentication -----------------
+
+    [Fact]
+    public async Task PublishSubAgent_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = CreateSubAgentUpload("no-auth-subagent", "1.0.0");
+        var response = await _fixture.HttpClient.PostAsync("/subagents", content, ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublishSubAgent_WithInvalidApiKey_Returns403()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = CreateSubAgentUpload("bad-key-subagent", "1.0.0");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/subagents") { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sk-invalid-key");
+
+        var response = await _fixture.HttpClient.SendAsync(request, ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteSubAgent_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _fixture.HttpClient.DeleteAsync("/subagents/nonexistent/1.0.0", ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ---- Task 4: manifest + artifact reads stay open (auth is enabled) ---
+
+    [Theory]
+    [InlineData("/manifest.json")]
+    [InlineData("/manifest/skills/index.json")]
+    [InlineData("/manifest/subagents/index.json")]
+    public async Task ManifestEndpoints_AreReadableWithoutAuth(string path)
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The fixture's HttpClient carries no Authorization header, yet the
+        // server is running with authentication enabled (see TestEnvironmentInitializer).
+        var response = await _fixture.HttpClient.GetAsync(path, ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ArtifactEndpoints_AreReadableWithoutAuth()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"sec-skill-{Guid.NewGuid():N}"[..20];
+        var subAgentName = $"sec-agent-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        using var subAgentUpload = CreateSubAgentUpload(subAgentName, "1.0.0");
+        (await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", subAgentUpload, ct))
+            .EnsureSuccessStatusCode();
+
+        string[] openArtifacts =
+        [
+            $"/skills/{skillName}/1.0.0/SKILL.md",
+            $"/skills/{skillName}/1.0.0/archive.zip",
+            $"/skills/{skillName}/1.0.0/references/guide.md",
+            $"/subagents/{subAgentName}/1.0.0/agent.md"
+        ];
+
+        foreach (var artifact in openArtifacts)
+        {
+            var response = await _fixture.HttpClient.GetAsync(artifact, ct);
+            Assert.True(
+                response.StatusCode == HttpStatusCode.OK,
+                $"Expected 200 for unauthenticated GET {artifact}, got {(int)response.StatusCode}.");
+        }
+    }
+
+    // ---- Task 3: resource downloads reject path traversal ---------------
+
+    [Theory]
+    [InlineData("..%2f..%2fSKILL.md")]
+    [InlineData("references%2f..%2f..%2f..%2fappsettings.json")]
+    public async Task SkillResourceDownload_WithTraversalPath_DoesNotEscape(string traversalPath)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"trav-skill-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        var response = await _fixture.HttpClient.GetAsync(
+            $"/skills/{skillName}/1.0.0/{traversalPath}", ct);
+
+        // A traversal path must never resolve to a real file. Resource lookup is
+        // by exact stored relative-path equality, so this yields a 404 rather than
+        // leaking bytes outside the skill's resource set.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ---- Task 2: archive downloads are digest-verified ------------------
+
+    [Fact]
+    public async Task DownloadVerifiedSkillArchive_WithTamperedDigest_Throws()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"digest-skill-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        var detail = await _fixture.Client.GetNativeSkillVersionAsync(skillName, "1.0.0", ct);
+        Assert.NotNull(detail);
+        // A resourceful skill is served as a deterministic archive artifact.
+        Assert.Equal("archive", detail.Artifact.Type);
+
+        await using var destination = new MemoryStream();
+        await Assert.ThrowsAsync<InvalidDataException>(() => _fixture.Client.DownloadVerifiedArtifactAsync(
+            detail.Artifact.Url,
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            destination,
+            ct));
+    }
+}


### PR DESCRIPTION
Closes #93.

Hardens the native manifest / sub-agent / skill-archive sync surface. The core controls already existed (digest verification, path-traversal guards, unix-mode safety, the API-key endpoint filter); this PR closes the **coverage and documentation** gaps that #93 called out.

## Tests (net-new)
`tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs`
- **Auth on sub-agent writes** (was untested): `POST /subagents` → 401 (no key) / 403 (bad key); `DELETE /subagents/{name}/{version}` → 401.
- **Manifest + artifact reads stay open** while auth is enabled: `/manifest.json`, `/manifest/skills/index.json`, `/manifest/subagents/index.json`, and `SKILL.md` / `archive.zip` / per-file resource / `agent.md`.
- **Path traversal** on resource download resolves to 404, not a file leak.
- **Digest mismatch** on a verified `archive.zip` download throws `InvalidDataException`.

`tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs`
- **Forward compatibility**: the client tolerates unknown manifest `kind`s, unknown artifact `type`s, and unrecognized fields instead of failing to parse (task 5).

## Docs
- **New `docs/specs/security.md`** — trust boundaries, auth model, digest verification, path-traversal handling, archive-extraction-is-the-consumer's-responsibility (zip-slip), sub-agent prompt-distribution risk, executable resource modes, and sync safety. Linked from README, the spec index, and `native-manifest.md`.
- **`docs/specs/skills.md`** — corrected the stale claim that archives "are not built or served" (they now are), and documented the automatic startup backfill migration for existing resourceful skills (task 6).

## Verification
- `dotnet build -c Release` — 0 warnings / 0 errors
- `dotnet test -c Release` — 214/214 pass (+13 new)
- `dotnet slopwatch analyze` — 0 issues
- `scripts/Add-FileHeaders.ps1 -Verify` — all headers present

No production behavior changes; additive tests + docs only. Existing RFC feed consumers remain compatible.