### PR TITLE
feat: add API versioning and gallery UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SkillServer implements Agent Skills standards and defines native extensions for 
 | [Skill Packages](docs/specs/skills.md) | How to author and publish AgentSkills.io-compatible SkillServer skills. |
 | [Sub-Agent Packages](docs/specs/subagents.md) | How NetClaw sub-agent definitions are authored and how SkillServer will publish them. |
 | [Native Manifest](docs/specs/native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future native resources. |
+| [Security And Trust Model](docs/specs/security.md) | Trust boundaries, authentication, digest verification, and sync safety for native sync. |
 | [Sub-Agent Sync Epic](docs/epics/subagent-sync.md) | Requirements and proposed GitHub issue breakdown for native manifest and sub-agent sync. |
 
 ## Quick Start

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,3 +9,4 @@ Some documents are target designs for upcoming work. Each spec calls out current
 | [Skill Packages](skills.md) | AgentSkills.io-compatible skill authoring and SkillServer artifact projection. |
 | [Sub-Agent Packages](subagents.md) | NetClaw sub-agent definition format and proposed SkillServer publication model. |
 | [Native Manifest](native-manifest.md) | Planned non-RFC sync feed for skills, sub-agents, and future artifact types. |
+| [Security And Trust Model](security.md) | Trust boundaries, authentication, digest verification, and sync safety for native sync. |

--- a/docs/specs/native-manifest.md
+++ b/docs/specs/native-manifest.md
@@ -264,6 +264,8 @@ Read access may be open for public registries. Private registries may require th
 
 Clients should send configured credentials to both manifest and artifact URLs for the same feed origin.
 
+See the [Security And Trust Model](security.md) for the full trust boundaries, digest-verification requirements, archive-extraction responsibilities, and sync-safety behavior that apply to native sync.
+
 ## Compatibility With The RFC Feed
 
 The RFC feed remains the compatibility contract for generic AgentSkills.io clients.

--- a/docs/specs/security.md
+++ b/docs/specs/security.md
@@ -1,0 +1,90 @@
+# SkillServer Security And Trust Model
+
+Status: current.
+
+This document states the trust assumptions and safety behavior for SkillServer's native sync surface: the native manifest, skill archive artifacts, and sub-agent definitions. It is a threat model, not a vulnerability-disclosure policy.
+
+## Scope
+
+- Native manifest traversal (`/manifest.json` and linked documents).
+- Skill artifacts (`skill-md` and `archive`) and their downloads.
+- Sub-agent `agent-md` artifacts and their distribution.
+- The `Netclaw.SkillClient` verified-download primitives and CLI sync commands.
+
+Out of scope: how a consuming runtime executes synced content, and the local filesystem layout each client chooses.
+
+## Trust Boundaries
+
+| Boundary | Trusted party | Threat if violated |
+|----------|---------------|--------------------|
+| Client → server writes | Holders of a valid API key | Unauthorized publication or deletion of skills/sub-agents. |
+| Server → client reads | The registry origin | Tampered or substituted artifact bytes. |
+| Artifact author → consumer | Whoever can publish to the feed | Malicious skill scripts or sub-agent prompts distributed to every consumer. |
+| Consumer runtime → host | The consuming client/agent | Unsafe archive extraction or execution of untrusted resources. |
+
+The central assumption: **publishing to a feed is equivalent to influencing the behavior of every consumer that syncs it.** A registry's write access must be guarded accordingly.
+
+## Authentication And Authorization
+
+- Authentication uses a bearer API key (`Authorization: Bearer <key>`). Keys are stored SHA-256 hashed.
+- Enforcement is a single endpoint filter applied only to **write** endpoints: `POST /skills`, `DELETE /skills/{name}/{version}`, `POST /subagents`, `DELETE /subagents/{name}/{version}`, and `/api-keys`.
+- Missing/empty/wrong-scheme credentials return **401**; a well-formed but invalid or expired key returns **403**.
+- When no keys are configured, authentication is disabled and the server is fully open. This is intended only for private/trusted-network deployments; a public registry must configure at least one key.
+- **Reads are open by default**: the manifest, RFC index, and all artifact endpoints (`SKILL.md`, `archive.zip`, per-file resources, `agent.md`, blobs) do not require a key even while write authentication is enabled. A private registry that must gate reads should place SkillServer behind a network boundary or an authenticating proxy; clients send configured credentials to both manifest and artifact URLs for the same origin.
+
+## Integrity: Digest Verification
+
+- Every artifact in the RFC feed and native manifest carries a `sha256:{hex}` digest of the exact bytes at its `url`.
+- Clients **must** verify the digest before installing an artifact. `Netclaw.SkillClient` computes the hash while streaming the download and throws `InvalidDataException` on mismatch.
+- The CLI `download-subagent` command stages the download to a temporary file, verifies the digest, and only then moves it into place; it never leaves a partial or unverified file, and refuses to overwrite an existing destination without `--force`.
+- Because blobs are content-addressed by SHA-256, a substituted or corrupted artifact cannot match its advertised digest.
+
+## Path Traversal And Resource Naming
+
+- Resource relative paths are validated on upload and backfill: leading `/`, drive/scheme markers (`:`), NUL bytes, `.`/`..` segments, and bare root filenames are rejected.
+- Resource downloads resolve by **exact stored relative-path equality**, not a filesystem join, so a traversal path simply fails to match and returns 404 rather than escaping the skill's resource set.
+- Skill archives contain only regular-file entries. Symbolic links and reparse points are rejected at publish time and are never emitted into an archive, so the server cannot distribute a link-based escape.
+
+## Archive Extraction Is The Consumer's Responsibility
+
+SkillServer builds archives from validated paths and **never extracts them**. `Netclaw.SkillClient` downloads and verifies archive **bytes only** — it does not unpack them.
+
+Any consumer that extracts `archive.zip` owns the extraction safety and **must**:
+
+- Reject entries whose resolved path escapes the destination directory (zip-slip).
+- Treat archive members as untrusted content, including their preserved Unix permission bits.
+- Apply its own policy for which resources may be marked executable or run.
+
+## Executable Resource Modes
+
+- Unix permission bits are preserved end-to-end (publish → archive → download), masked to standard permission bits (`0`–`511`). Type bits and setuid/setgid/sticky bits are stripped; a mode outside that range is rejected on upload.
+- A synced executable resource therefore runs with the author's intended permissions. Consumers must treat such scripts as untrusted code and gate execution on feed trust.
+
+## Sub-Agent Prompt Distribution
+
+A sub-agent `agent-md` body becomes a **system prompt** inside the consuming runtime. Distributing a sub-agent is distributing executable instructions, and is a prompt-injection vector.
+
+Trust assumptions for consumers:
+
+- Sync sub-agents only from trusted feeds.
+- Keep user-authored local definitions authoritative; server-synced files must never overwrite them.
+- Install server-synced definitions into a managed, clearly-scoped location that can be pruned without touching user files.
+- Review server-synced prompts as you would review third-party code.
+
+## Sync Safety
+
+- **Non-destructive**: a failed sync (network error, digest mismatch) leaves existing local artifacts in place.
+- **Prune-after-confirm**: server-synced artifacts are removed only after a successful collection sync confirms the server no longer advertises them.
+- **User files win**: user-authored local files take precedence over server-synced files with the same identity.
+- **No prescribed paths**: the server protocol carries `name`, `version`, `kind`, `type`, `url`, and `digest`; local filesystem layout is entirely the client's choice.
+
+## Forward Compatibility
+
+Clients must ignore unsupported resource `kind`s, unknown artifact `type`s, and unrecognized fields rather than failing to parse them. This lets a newer server introduce collections or artifact types without breaking older clients, and keeps the RFC skill feed compatible for generic AgentSkills.io consumers.
+
+## Summary Of Trust Assumptions
+
+- The registry operator is trusted to control who can publish and delete.
+- Artifact authors are trusted to the extent the feed's write access is controlled — publishing runs code and prompts on consumers.
+- Transport integrity is enforced by digest verification, not assumed from the network.
+- Consumers are responsible for safe extraction and execution of the verified bytes they receive.

--- a/docs/specs/skills.md
+++ b/docs/specs/skills.md
@@ -115,21 +115,27 @@ The native manifest must reuse this object instead of inventing another skill in
 
 ## Resource Distribution
 
-Target behavior:
+SkillServer projects skills into two artifact shapes:
 
-- Skills with only `SKILL.md` should publish as `type: "skill-md"`.
-- Skills with supporting files should publish as `type: "archive"`.
-- SkillServer standardizes archive artifacts on `.zip` at `/skills/{name}/{version}/archive.zip`.
-- Archive artifacts should contain `SKILL.md` at the archive root plus supporting files under their relative paths.
-- The RFC feed and native manifest should point to the same artifact URL and digest for a given skill version.
-- Archive artifact digest and size metadata must be additive. Existing `SKILL.md` digest behavior must remain available for compatibility with current skill download and verification APIs.
+- Skills with only `SKILL.md` publish as `type: "skill-md"`.
+- Skills with supporting files publish as `type: "archive"`.
+- Archive artifacts are standardized on `.zip` and served at `/skills/{name}/{version}/archive.zip`.
+- Archive artifacts contain `SKILL.md` at the archive root plus supporting files under their relative paths.
+- Archives are deterministic: entries are ordered, timestamps are fixed, and Unix permission bits are preserved (masked to standard permission bits) so an executable resource stays executable after extraction.
+- The RFC feed and native manifest point to the same artifact URL and digest for a given skill version.
+- Archive artifact digest and size metadata are additive. The original `SKILL.md` digest remains available for compatibility with existing skill download and verification APIs.
+- Per-file resource routes at `/skills/{name}/{version}/{path}` remain available for compatibility.
 
-Current implementation gap:
+### Migration For Existing Resourceful Skills
 
-- SkillServer currently stores resource files individually and exposes them through a `resources` extension in the RFC-shaped index.
-- SkillServer has an `archive` type constant but does not currently build or serve skill archives.
+Skills published before archive support existed were stored as individual resource files with only a `skill-md` artifact. SkillServer backfills these automatically; no manual re-publish is required.
 
-The migration path is to add archive artifact support while preserving existing per-file resource routes for compatibility.
+- On startup, a one-time backfill scans versioned skills that have resources but no archive artifact.
+- For each, it builds the deterministic archive from the stored `SKILL.md` and resource blobs, stores it as a content-addressed blob, and records the additive `archive` artifact metadata.
+- The original `SKILL.md` bytes, digest, and per-file resource routes are preserved, so existing RFC feed consumers and `skill-md` download/verification callers are unaffected.
+- Backfill is additive and idempotent: a version that already has an archive artifact is skipped, and a failed backfill leaves the existing `skill-md` artifact and per-file routes intact.
+
+Clients that only understand `skill-md` continue to work; clients that understand archives pick up the archive artifact on their next sync.
 
 ## Validation Requirements
 

--- a/src/Netclaw.SkillClient/NativeManifestClient.cs
+++ b/src/Netclaw.SkillClient/NativeManifestClient.cs
@@ -12,21 +12,21 @@ public sealed partial class SkillServerClient
     public async Task<NativeRootManifest?> GetManifestAsync(CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            "manifest.json",
+            Api("manifest.json"),
             SkillServerClientJsonContext.Default.NativeRootManifest,
             ct);
     }
 
     public Task<NativeSkillCollectionIndex?> GetNativeSkillIndexAsync(CancellationToken ct = default)
     {
-        return GetNativeSkillIndexByHrefAsync("manifest/skills/index.json", ct);
+        return GetNativeSkillIndexByHrefAsync(Api("manifest/skills/index.json"), ct);
     }
 
     public Task<NativeSkillCollectionIndex?> GetNativeSkillIndexAsync(
         NativeManifestLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSkillIndexByHrefAsync(link.Href, ct);
+        return GetNativeSkillIndexByHrefAsync(ResolveHref(link.Href), ct);
     }
 
     public async Task<NativeSkillCollectionIndex?> GetNativeSkillIndexByHrefAsync(
@@ -34,7 +34,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSkillCollectionIndex,
             ct);
     }
@@ -43,7 +43,7 @@ public sealed partial class SkillServerClient
         NativeManifestPageLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSkillPageAsync(link.Href, ct);
+        return GetNativeSkillPageAsync(ResolveHref(link.Href), ct);
     }
 
     public async Task<NativeSkillCollectionPage?> GetNativeSkillPageAsync(
@@ -51,7 +51,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSkillCollectionPage,
             ct);
     }
@@ -60,7 +60,7 @@ public sealed partial class SkillServerClient
         NativeSkillPageItem item,
         CancellationToken ct = default)
     {
-        return GetNativeSkillIdentityByHrefAsync(item.Href, ct);
+        return GetNativeSkillIdentityByHrefAsync(ResolveHref(item.Href), ct);
     }
 
     public Task<NativeSkillIdentityIndex?> GetNativeSkillIdentityAsync(string name, CancellationToken ct = default)
@@ -75,7 +75,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSkillIdentityIndex,
             ct);
     }
@@ -84,7 +84,7 @@ public sealed partial class SkillServerClient
         NativeSkillVersionLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSkillVersionByHrefAsync(link.Href, ct);
+        return GetNativeSkillVersionByHrefAsync(ResolveHref(link.Href), ct);
     }
 
     public Task<NativeSkillVersionDetail?> GetNativeSkillVersionAsync(
@@ -102,21 +102,21 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSkillVersionDetail,
             ct);
     }
 
     public Task<NativeSubAgentCollectionIndex?> GetNativeSubAgentIndexAsync(CancellationToken ct = default)
     {
-        return GetNativeSubAgentIndexByHrefAsync("manifest/subagents/index.json", ct);
+        return GetNativeSubAgentIndexByHrefAsync(Api("manifest/subagents/index.json"), ct);
     }
 
     public Task<NativeSubAgentCollectionIndex?> GetNativeSubAgentIndexAsync(
         NativeManifestLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSubAgentIndexByHrefAsync(link.Href, ct);
+        return GetNativeSubAgentIndexByHrefAsync(ResolveHref(link.Href), ct);
     }
 
     public async Task<NativeSubAgentCollectionIndex?> GetNativeSubAgentIndexByHrefAsync(
@@ -124,7 +124,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSubAgentCollectionIndex,
             ct);
     }
@@ -133,7 +133,7 @@ public sealed partial class SkillServerClient
         NativeManifestPageLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSubAgentPageAsync(link.Href, ct);
+        return GetNativeSubAgentPageAsync(ResolveHref(link.Href), ct);
     }
 
     public async Task<NativeSubAgentCollectionPage?> GetNativeSubAgentPageAsync(
@@ -141,7 +141,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSubAgentCollectionPage,
             ct);
     }
@@ -150,7 +150,7 @@ public sealed partial class SkillServerClient
         NativeSubAgentPageItem item,
         CancellationToken ct = default)
     {
-        return GetNativeSubAgentIdentityByHrefAsync(item.Href, ct);
+        return GetNativeSubAgentIdentityByHrefAsync(ResolveHref(item.Href), ct);
     }
 
     public Task<NativeSubAgentIdentityIndex?> GetNativeSubAgentIdentityAsync(
@@ -167,7 +167,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSubAgentIdentityIndex,
             ct);
     }
@@ -176,7 +176,7 @@ public sealed partial class SkillServerClient
         NativeSubAgentVersionLink link,
         CancellationToken ct = default)
     {
-        return GetNativeSubAgentVersionByHrefAsync(link.Href, ct);
+        return GetNativeSubAgentVersionByHrefAsync(ResolveHref(link.Href), ct);
     }
 
     public Task<NativeSubAgentVersionDetail?> GetNativeSubAgentVersionAsync(
@@ -194,8 +194,17 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            href,
+            ResolveHref(href),
             SkillServerClientJsonContext.Default.NativeSubAgentVersionDetail,
             ct);
+    }
+
+    /*
+     * Resolve an href: if it already starts with "/" it's an absolute path from the server
+     * root (as returned by manifest links), otherwise prepend the API base.
+     */
+    private string ResolveHref(string href)
+    {
+        return href.StartsWith('/') ? href : Api(href);
     }
 }

--- a/src/Netclaw.SkillClient/NativeManifestModels.cs
+++ b/src/Netclaw.SkillClient/NativeManifestModels.cs
@@ -32,6 +32,9 @@ public sealed record NativeRootManifestLinks
 
     [JsonPropertyName("subagents")]
     public NativeManifestLink SubAgents { get; init; } = new();
+
+    [JsonPropertyName("apiBase")]
+    public NativeManifestLink ApiBase { get; init; } = new();
 }
 
 public sealed record NativeRootManifest

--- a/src/Netclaw.SkillClient/SkillServerClient.cs
+++ b/src/Netclaw.SkillClient/SkillServerClient.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SkillServerClient.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -18,11 +18,13 @@ public sealed partial class SkillServerClient : IDisposable
     private readonly HttpClient _httpClient;
     private readonly bool _ownsHttpClient;
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _apiBase;
 
     public SkillServerClient(string serverUrl, string? apiKey = null)
     {
         _httpClient = new HttpClient { BaseAddress = new Uri(serverUrl.TrimEnd('/') + "/") };
         _ownsHttpClient = true;
+        _apiBase = "api/v1";
         if (!string.IsNullOrEmpty(apiKey))
             _httpClient.DefaultRequestHeaders.Authorization =
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
@@ -36,11 +38,14 @@ public sealed partial class SkillServerClient : IDisposable
     {
         _httpClient = httpClient;
         _ownsHttpClient = false;
+        _apiBase = "api/v1";
         _jsonOptions = new JsonSerializerOptions
         {
             TypeInfoResolver = SkillServerClientJsonContext.Default
         };
     }
+
+    private string Api(string path) => $"{_apiBase}/{path.TrimStart('/')}";
 
     /// <summary>
     /// Gets the RFC-compliant skill index per Cloudflare Agent Skills Discovery RFC v0.2.0.
@@ -65,7 +70,7 @@ public sealed partial class SkillServerClient : IDisposable
         if (skip.HasValue) query.Add($"skip={skip.Value}");
         if (take.HasValue) query.Add($"take={take.Value}");
 
-        var url = query.Count > 0 ? $"skills?{string.Join("&", query)}" : "skills";
+        var url = query.Count > 0 ? $"{Api("skills")}?{string.Join("&", query)}" : Api("skills");
 
         var result = await _httpClient.GetFromJsonAsync(
             url,
@@ -80,7 +85,7 @@ public sealed partial class SkillServerClient : IDisposable
     public async Task<IReadOnlyList<SkillVersionSummary>> GetSkillVersionsAsync(string name, CancellationToken ct = default)
     {
         var result = await _httpClient.GetFromJsonAsync(
-            $"skills/{Uri.EscapeDataString(name)}",
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}",
             SkillServerClientJsonContext.Default.IReadOnlyListSkillVersionSummary,
             ct);
         return result ?? [];
@@ -92,7 +97,7 @@ public sealed partial class SkillServerClient : IDisposable
     public async Task<SkillVersionSummary?> GetVersionAsync(string name, string version, CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            $"skills/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
             SkillServerClientJsonContext.Default.SkillVersionSummary,
             ct);
     }
@@ -103,7 +108,7 @@ public sealed partial class SkillServerClient : IDisposable
     public async Task<Stream> GetSkillFileAsync(string name, string version, string path = "SKILL.md", CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync(
-            $"skills/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/{path}",
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/{path}",
             ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStreamAsync(ct);
@@ -115,7 +120,7 @@ public sealed partial class SkillServerClient : IDisposable
     public async Task<string> GetSkillFileAsStringAsync(string name, string version, string path = "SKILL.md", CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync(
-            $"skills/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/{path}",
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/{path}",
             ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStringAsync(ct);
@@ -130,7 +135,7 @@ public sealed partial class SkillServerClient : IDisposable
             ? digest[7..]
             : digest;
 
-        var response = await _httpClient.GetAsync($"blobs/sha256/{normalizedDigest}", ct);
+        var response = await _httpClient.GetAsync($"{Api("blobs/sha256")}/{normalizedDigest}", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStreamAsync(ct);
     }
@@ -160,29 +165,30 @@ public sealed partial class SkillServerClient : IDisposable
         if (skip.HasValue) queryParams.Add($"skip={skip.Value}");
         if (take.HasValue) queryParams.Add($"take={take.Value}");
 
-        var url = $"skills?{string.Join("&", queryParams)}";
-        var result = await _httpClient.GetFromJsonAsync(url,
-            SkillServerClientJsonContext.Default.IReadOnlyListSkillSummary, ct);
+        var url = $"{Api("skills")}?{string.Join("&", queryParams)}";
+
+        var result = await _httpClient.GetFromJsonAsync(
+            url,
+            SkillServerClientJsonContext.Default.IReadOnlyListSkillSummary,
+            ct);
         return result ?? [];
     }
 
     /// <summary>
-    /// Gets the latest version of a skill by name.
+    /// Gets the latest version of a skill.
     /// </summary>
     public async Task<SkillVersionSummary?> GetLatestVersionAsync(string name, CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            $"skills/{Uri.EscapeDataString(name)}/latest",
-            SkillServerClientJsonContext.Default.SkillVersionSummary, ct);
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}/latest",
+            SkillServerClientJsonContext.Default.SkillVersionSummary,
+            ct);
     }
 
-    /// <summary>
-    /// Checks if any of the specified skills have newer versions available.
-    /// </summary>
     public async Task<IReadOnlyList<CheckUpdateResponse>> CheckUpdatesAsync(
         IReadOnlyList<CheckUpdateRequest> items, CancellationToken ct = default)
     {
-        var response = await _httpClient.PostAsJsonAsync("skills/check-updates", items,
+        var response = await _httpClient.PostAsJsonAsync(Api("skills/check-updates"), items,
             SkillServerClientJsonContext.Default.IReadOnlyListCheckUpdateRequest, ct);
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync(
@@ -282,13 +288,13 @@ public sealed partial class SkillServerClient : IDisposable
             content.Add(new StringContent(json), "resourceMetadata");
         }
 
-        return await _httpClient.PostAsync("skills", content, ct);
+        return await _httpClient.PostAsync(Api("skills"), content, ct);
     }
 
     public async Task DeleteVersionAsync(string name, string version, CancellationToken ct = default)
     {
         var response = await _httpClient.DeleteAsync(
-            $"skills/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}", ct);
+            $"{Api("skills")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}", ct);
         response.EnsureSuccessStatusCode();
     }
 
@@ -296,7 +302,7 @@ public sealed partial class SkillServerClient : IDisposable
         string label, DateTimeOffset? expiresAt = null, CancellationToken ct = default)
     {
         var request = new CreateApiKeyRequest { Label = label, ExpiresAt = expiresAt };
-        var response = await _httpClient.PostAsJsonAsync("api-keys",
+        var response = await _httpClient.PostAsJsonAsync(Api("api-keys"),
             request, SkillServerClientJsonContext.Default.CreateApiKeyRequest, ct);
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync(
@@ -305,14 +311,14 @@ public sealed partial class SkillServerClient : IDisposable
 
     public async Task<IReadOnlyList<ApiKeySummary>> ListApiKeysAsync(CancellationToken ct = default)
     {
-        var result = await _httpClient.GetFromJsonAsync("api-keys",
+        var result = await _httpClient.GetFromJsonAsync(Api("api-keys"),
             SkillServerClientJsonContext.Default.IReadOnlyListApiKeySummary, ct);
         return result ?? [];
     }
 
     public async Task DeleteApiKeyAsync(long id, CancellationToken ct = default)
     {
-        var response = await _httpClient.DeleteAsync($"api-keys/{id}", ct);
+        var response = await _httpClient.DeleteAsync($"{Api("api-keys")}/{id}", ct);
         response.EnsureSuccessStatusCode();
     }
 

--- a/src/Netclaw.SkillClient/SubAgentClient.cs
+++ b/src/Netclaw.SkillClient/SubAgentClient.cs
@@ -13,7 +13,7 @@ public sealed partial class SkillServerClient
     public async Task<IReadOnlyList<SubAgentSummary>> ListSubAgentsAsync(CancellationToken ct = default)
     {
         var result = await _httpClient.GetFromJsonAsync(
-            "subagents",
+            Api("subagents"),
             SkillServerClientJsonContext.Default.IReadOnlyListSubAgentSummary,
             ct);
         return result ?? [];
@@ -24,7 +24,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         var result = await _httpClient.GetFromJsonAsync(
-            $"subagents/{Uri.EscapeDataString(name)}",
+            $"{Api("subagents")}/{Uri.EscapeDataString(name)}",
             SkillServerClientJsonContext.Default.IReadOnlyListSubAgentVersionSummary,
             ct);
         return result ?? [];
@@ -36,7 +36,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         return await _httpClient.GetFromJsonAsync(
-            $"subagents/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
+            $"{Api("subagents")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
             SkillServerClientJsonContext.Default.SubAgentVersionSummary,
             ct);
     }
@@ -44,7 +44,7 @@ public sealed partial class SkillServerClient
     public async Task<Stream> GetSubAgentFileAsync(string name, string version, CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync(
-            $"subagents/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/agent.md",
+            $"{Api("subagents")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/agent.md",
             ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStreamAsync(ct);
@@ -56,7 +56,7 @@ public sealed partial class SkillServerClient
         CancellationToken ct = default)
     {
         var response = await _httpClient.GetAsync(
-            $"subagents/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/agent.md",
+            $"{Api("subagents")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}/agent.md",
             ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStringAsync(ct);
@@ -94,7 +94,7 @@ public sealed partial class SkillServerClient
     public async Task DeleteSubAgentVersionAsync(string name, string version, CancellationToken ct = default)
     {
         var response = await _httpClient.DeleteAsync(
-            $"subagents/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
+            $"{Api("subagents")}/{Uri.EscapeDataString(name)}/{Uri.EscapeDataString(version)}",
             ct);
         response.EnsureSuccessStatusCode();
     }
@@ -110,6 +110,6 @@ public sealed partial class SkillServerClient
         content.Add(new StringContent(version), "version");
         content.Add(new StreamContent(agentMdContent), "file", "agent.md");
 
-        return await _httpClient.PostAsync("subagents", content, ct);
+        return await _httpClient.PostAsync(Api("subagents"), content, ct);
     }
 }

--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -38,7 +38,7 @@ public static class Endpoints
 
     private static void MapManifestEndpoints(this WebApplication app)
     {
-        app.MapGet("/manifest.json", async (
+        app.MapGet("/api/v1/manifest.json", async (
             NativeManifestGenerator manifestGenerator,
             CancellationToken ct) =>
         {
@@ -46,7 +46,7 @@ public static class Endpoints
             return Results.Json(manifest, SkillServerJsonContext.Default.NativeRootManifest);
         });
 
-        var manifest = app.MapGroup("/manifest");
+        var manifest = app.MapGroup("/api/v1/manifest");
 
         manifest.MapGet("/skills/index.json", async (
             NativeManifestGenerator manifestGenerator,
@@ -135,7 +135,7 @@ public static class Endpoints
 
     private static void MapSkillEndpoints(this WebApplication app)
     {
-        var skills = app.MapGroup("/skills");
+        var skills = app.MapGroup("/api/v1/skills");
 
         skills.MapGet("/", ListSkills);
         skills.MapGet("/{name}", GetSkill);
@@ -151,7 +151,7 @@ public static class Endpoints
 
     private static void MapSubAgentEndpoints(this WebApplication app)
     {
-        var subagents = app.MapGroup("/subagents");
+        var subagents = app.MapGroup("/api/v1/subagents");
 
         subagents.MapGet("/", ListSubAgents);
         subagents.MapGet("/{name}", GetSubAgent);
@@ -502,13 +502,13 @@ public static class Endpoints
         var baseUrl = configuration["SkillServer:BaseUrl"]?.TrimEnd('/') ?? "http://localhost:8080";
 
         return Results.Created(
-            $"/skills/{result.Name}/{result.Version}",
+            $"/api/v1/skills/{result.Name}/{result.Version}",
             new SkillUploadResponse
             {
                 Name = result.Name!.Value.Value,
                 Version = result.Version!.Value.Value,
                 Sha256 = result.Digest!.Value.Value,
-                Url = $"{baseUrl}/skills/{result.Name}/{result.Version}/SKILL.md"
+                Url = $"{baseUrl}/api/v1/skills/{result.Name}/{result.Version}/SKILL.md"
             });
     }
 
@@ -736,13 +736,13 @@ public static class Endpoints
 
         var baseUrl = configuration["SkillServer:BaseUrl"]?.TrimEnd('/') ?? "http://localhost:8080";
         return Results.Created(
-            $"/subagents/{result.Name}/{result.Version}",
+            $"/api/v1/subagents/{result.Name}/{result.Version}",
             new SubAgentUploadResponse
             {
                 Name = result.Name!.Value.Value,
                 Version = result.Version!.Value.Value,
                 Sha256 = result.Digest!.Value.Value,
-                Url = $"{baseUrl}/subagents/{result.Name}/{result.Version}/agent.md"
+                Url = $"{baseUrl}/api/v1/subagents/{result.Name}/{result.Version}/agent.md"
             });
     }
 
@@ -781,7 +781,7 @@ public static class Endpoints
 
     private static void MapApiKeyEndpoints(this WebApplication app)
     {
-        var keys = app.MapGroup("/api-keys")
+        var keys = app.MapGroup("/api/v1/api-keys")
             .AddEndpointFilter<ApiKeyEndpointFilter>();
 
         keys.MapPost("/", CreateApiKey);
@@ -806,7 +806,7 @@ public static class Endpoints
         var (rawKey, storedKey) = await apiKeyService.CreateKeyAsync(
             request.Label, request.ExpiresAt, ct);
 
-        return Results.Created($"/api-keys/{storedKey.Id}", new CreateApiKeyResponse
+        return Results.Created($"/api/v1/api-keys/{storedKey.Id}", new CreateApiKeyResponse
         {
             Id = storedKey.Id,
             Label = storedKey.Label,
@@ -852,7 +852,7 @@ public static class Endpoints
 
     private static void MapBlobEndpoints(this WebApplication app)
     {
-        app.MapGet("/blobs/sha256/{digest}", (
+        app.MapGet("/api/v1/blobs/sha256/{digest}", (
             string digest,
             BlobStorage blobStorage) =>
         {

--- a/src/SkillServer/Models/NativeManifest.cs
+++ b/src/SkillServer/Models/NativeManifest.cs
@@ -32,6 +32,9 @@ public sealed record NativeRootManifestLinks
 
     [JsonPropertyName("subagents")]
     public required NativeManifestLink SubAgents { get; init; }
+
+    [JsonPropertyName("apiBase")]
+    public required NativeManifestLink ApiBase { get; init; }
 }
 
 public sealed record NativeRootManifest
@@ -41,6 +44,9 @@ public sealed record NativeRootManifest
 
     [JsonPropertyName("generatedAt")]
     public required DateTimeOffset GeneratedAt { get; init; }
+
+    [JsonPropertyName("apiVersion")]
+    public string? ApiVersion { get; init; }
 
     [JsonPropertyName("links")]
     public required NativeRootManifestLinks Links { get; init; }

--- a/src/SkillServer/Program.cs
+++ b/src/SkillServer/Program.cs
@@ -1,8 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Program.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.AspNetCore.StaticFiles;
 using SkillServer;
 using SkillServer.Data;
 using SkillServer.Models;
@@ -51,7 +52,14 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
+// Serve static files for gallery UI
+app.UseStaticFiles();
+
+// Map API endpoints (must be before fallback)
 app.MapSkillServerEndpoints();
+
+// Serve gallery UI for non-API paths
+app.MapFallbackToFile("index.html");
 
 app.Run();
 

--- a/src/SkillServer/Services/IndexGenerator.cs
+++ b/src/SkillServer/Services/IndexGenerator.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="IndexGenerator.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -47,8 +47,8 @@ public sealed class IndexGenerator
                 Type = v.SkillType,
                 Description = v.Description,
                 Url = v.SkillType == SkillTypes.SkillMd
-                    ? $"{baseUrl}/skills/{v.SkillName}/{v.Version}/SKILL.md"
-                    : $"{baseUrl}/skills/{v.SkillName}/{v.Version}/archive.zip",
+                    ? $"{baseUrl}/api/v1/skills/{v.SkillName}/{v.Version}/SKILL.md"
+                    : $"{baseUrl}/api/v1/skills/{v.SkillName}/{v.Version}/archive.zip",
                 Digest = Sha256Digest.Create(v.ArtifactSha256).Value,
                 Version = v.Version,
                 Resources = files.Count > 0
@@ -56,7 +56,7 @@ public sealed class IndexGenerator
                     {
                         Path = f.RelativePath,
                         Digest = Sha256Digest.Create(f.Sha256).Value,
-                        Url = $"{baseUrl}/skills/{v.SkillName}/{v.Version}/{f.RelativePath}",
+                        Url = $"{baseUrl}/api/v1/skills/{v.SkillName}/{v.Version}/{f.RelativePath}",
                         UnixMode = f.UnixMode
                     }).ToList()
                     : null

--- a/src/SkillServer/Services/NativeManifestGenerator.cs
+++ b/src/SkillServer/Services/NativeManifestGenerator.cs
@@ -32,12 +32,14 @@ public sealed class NativeManifestGenerator
         var manifest = new NativeRootManifest
         {
             GeneratedAt = DateTimeOffset.UtcNow,
+            ApiVersion = "v1",
             Links = new NativeRootManifestLinks
             {
-                Self = Link("/manifest.json"),
+                Self = Link("/api/v1/manifest.json"),
                 RfcSkills = Link("/.well-known/agent-skills/index.json"),
-                Skills = Link("/manifest/skills/index.json"),
-                SubAgents = Link("/manifest/subagents/index.json")
+                Skills = Link("/api/v1/manifest/skills/index.json"),
+                SubAgents = Link("/api/v1/manifest/subagents/index.json"),
+                ApiBase = Link("/api/v1")
             }
         };
 
@@ -48,11 +50,11 @@ public sealed class NativeManifestGenerator
     {
         var index = new NativeSkillCollectionIndex
         {
-            Links = SelfLinks("/manifest/skills/index.json"),
+            Links = SelfLinks("/api/v1/manifest/skills/index.json"),
             Pages = [new NativeManifestPageLink
             {
                 Range = SkillsPageRange,
-                Href = "/manifest/skills/pages/all.json"
+                Href = "/api/v1/manifest/skills/pages/all.json"
             }]
         };
 
@@ -84,7 +86,7 @@ public sealed class NativeManifestGenerator
                     Max = latest.Version,
                     Count = versions.Count
                 },
-                Href = $"/manifest/skills/{latest.SkillName}/index.json"
+                Href = $"/api/v1/manifest/skills/{latest.SkillName}/index.json"
             });
         }
 
@@ -92,7 +94,7 @@ public sealed class NativeManifestGenerator
         {
             Range = SkillsPageRange,
             Items = items,
-            Links = SelfLinks("/manifest/skills/pages/all.json")
+            Links = SelfLinks("/api/v1/manifest/skills/pages/all.json")
         };
     }
 
@@ -116,9 +118,9 @@ public sealed class NativeManifestGenerator
                 Version = v.Version,
                 PublishedAt = v.PublishedAt,
                 Digest = Sha256Digest.Create(v.ArtifactSha256).Value,
-                Href = $"/manifest/skills/{skill.Name}/versions/{v.Version}.json"
+                Href = $"/api/v1/manifest/skills/{skill.Name}/versions/{v.Version}.json"
             }).ToList(),
-            Links = SelfLinks($"/manifest/skills/{skill.Name}/index.json")
+            Links = SelfLinks($"/api/v1/manifest/skills/{skill.Name}/index.json")
         };
     }
 
@@ -140,9 +142,9 @@ public sealed class NativeManifestGenerator
                 : new NativeSubagentRoute
                 {
                     Name = skillVersion.RoutesToSubagent,
-                    Href = $"/manifest/subagents/{skillVersion.RoutesToSubagent}/index.json"
+                    Href = $"/api/v1/manifest/subagents/{skillVersion.RoutesToSubagent}/index.json"
                 },
-            Links = SelfLinks($"/manifest/skills/{skill.Name}/versions/{skillVersion.Version}.json")
+            Links = SelfLinks($"/api/v1/manifest/skills/{skill.Name}/versions/{skillVersion.Version}.json")
         };
     }
 
@@ -150,11 +152,11 @@ public sealed class NativeManifestGenerator
     {
         var index = new NativeSubAgentCollectionIndex
         {
-            Links = SelfLinks("/manifest/subagents/index.json"),
+            Links = SelfLinks("/api/v1/manifest/subagents/index.json"),
             Pages = [new NativeManifestPageLink
             {
                 Range = SubAgentsPageRange,
-                Href = "/manifest/subagents/pages/all.json"
+                Href = "/api/v1/manifest/subagents/pages/all.json"
             }]
         };
 
@@ -186,7 +188,7 @@ public sealed class NativeManifestGenerator
                     Max = latest.Version,
                     Count = versions.Count
                 },
-                Href = $"/manifest/subagents/{latest.SubAgentName}/index.json"
+                Href = $"/api/v1/manifest/subagents/{latest.SubAgentName}/index.json"
             });
         }
 
@@ -194,7 +196,7 @@ public sealed class NativeManifestGenerator
         {
             Range = SubAgentsPageRange,
             Items = items,
-            Links = SelfLinks("/manifest/subagents/pages/all.json")
+            Links = SelfLinks("/api/v1/manifest/subagents/pages/all.json")
         };
     }
 
@@ -218,9 +220,9 @@ public sealed class NativeManifestGenerator
                 Version = v.Version,
                 PublishedAt = v.PublishedAt,
                 Digest = Sha256Digest.Create(v.Sha256).Value,
-                Href = $"/manifest/subagents/{subAgent.Name}/versions/{v.Version}.json"
+                Href = $"/api/v1/manifest/subagents/{subAgent.Name}/versions/{v.Version}.json"
             }).ToList(),
-            Links = SelfLinks($"/manifest/subagents/{subAgent.Name}/index.json")
+            Links = SelfLinks($"/api/v1/manifest/subagents/{subAgent.Name}/index.json")
         };
     }
 
@@ -240,9 +242,9 @@ public sealed class NativeManifestGenerator
             Name = subAgent.Name,
             Version = subAgentVersion.Version,
             Description = subAgentVersion.Description,
-            Url = $"{baseUrl}/subagents/{subAgent.Name}/{subAgentVersion.Version}/agent.md",
+            Url = $"{baseUrl}/api/v1/subagents/{subAgent.Name}/{subAgentVersion.Version}/agent.md",
             Digest = Sha256Digest.Create(subAgentVersion.Sha256).Value,
-            Links = SelfLinks($"/manifest/subagents/{subAgent.Name}/versions/{subAgentVersion.Version}.json")
+            Links = SelfLinks($"/api/v1/manifest/subagents/{subAgent.Name}/versions/{subAgentVersion.Version}.json")
         };
     }
 
@@ -256,8 +258,8 @@ public sealed class NativeManifestGenerator
             Type = version.SkillType,
             Description = version.Description,
             Url = version.SkillType == SkillTypes.SkillMd
-                ? $"{baseUrl}/skills/{skillName}/{version.Version}/SKILL.md"
-                : $"{baseUrl}/skills/{skillName}/{version.Version}/archive.zip",
+                ? $"{baseUrl}/api/v1/skills/{skillName}/{version.Version}/SKILL.md"
+                : $"{baseUrl}/api/v1/skills/{skillName}/{version.Version}/archive.zip",
             Digest = Sha256Digest.Create(version.ArtifactSha256).Value
         };
     }

--- a/src/SkillServer/SkillServer.csproj
+++ b/src/SkillServer/SkillServer.csproj
@@ -45,4 +45,6 @@
     </None>
   </ItemGroup>
 
+  <!-- .NET SDK 10+ includes wwwroot implicitly as Content with CopyToPublishDirectory=PreserveNewest -->
+
 </Project>

--- a/src/SkillServer/wwwroot/index.html
+++ b/src/SkillServer/wwwroot/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SkillServer Gallery</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<!-- ═══ NAV ═══ -->
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="/" class="nav-brand">
+      <!-- Netclaw lobster icon (extracted from brand, white fill, no bg) -->
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" width="32" height="32">
+        <path d="M997.4 461.4c56.9-4 122.9 3.9 178.9 14.3 122 22.7 225.5 64 333.4 124.1 1.3 67-1.7 133.4 1.3 200.4.4 34.8 1.7 68.6-1.3 103.3-11.4 146.6-62.7 287.3-148.3 406.8-47.9 65.6-114.9 133.7-177.3 186 5.9-9 10.5-18.8 13.7-29.1 4.7-16.2 3.2-36.8-5.3-52.3-8.6-15.4-25.2-18.6-40.9-23.1 25.8-20.9 43.1-34.8 67.3-58.1 117.6-113.4 183.7-273.2 195.6-435 2.6-35.6 2.2-68.5 2.2-104.4L1417 660.8c-112.7-58.5-237-97.4-364.3-103-26.1-1.5-49.4-.5-75.4 1.3-124 8.4-234.9 45.9-345.1 101.4-.2 41.8-.1 83.5.3 125.3.193 70.3-.91 133.3 12.985 202.9 25.533 127.93 77.16 241.16 169.278 334.53 16.006 16.07 32.907 31.23 50.621 45.41 10.24 8.09 20.941 15.34 30.894 23.79-18.984 6.01-38.382 10.21-44.136 32.5-6.934 26.87 1.98 49.11 14.661 72.49-42.539-35.75-84.017-77.92-121.26-118.9-120.792-132.91-187.237-296.13-202.704-474.582-4.246-48.987-3.469-100.891-3.545-150.65L539.2 658.1c-.01-18.28-1.19-39.61.933-57.82C679.4 518 836.36 470.5 997.4 461.4z" fill="white"/>
+        <path d="M1012 1180.4c4.4-.52 13.33-.66 18.02-.48 33.49 1.3 70.13 15.87 93.92 39.72 4.68 4.9 7.94 11.8 7.33 18.72-1.17 13.51-21.58 26.17-31.78 34.41 8.53-.02 29.73.13 34.1 8.15 10.53 19.33-30.41 46.07-18.53 56.94 75.14-6.87 21.37 38.26-3.52 62-47.77-5.71-109.99 8.72-86.82 72.4-13.49 37.09-49.71 68.46-84.99 84.6-2.58-5.13-5.95-10.61-8.67-15.74-18.83-35.53-11.69-60.97 17.35-86.81-20.97 41.9-3.97 64.94-49.32 106.17-3.71 3.17-6.54 5.08-10.53 7.82-13.81-9.48-42.92-39.19-51.78-53.56-14.936-24.24-10.58-56.34-3.91-82.54-38.446 35.78-33.447 62.55-8.254 104.38-39.044-19.13-89.362-63.02-90.821-110.59-.338-11.02-6.439-23.14-14.437-30.65-21.367-20.08-50.599-18.12-77.838-17.64-10.108 9.93-41.699 37.31-40.567 51.54-.21 2.72-1.545 5.24-3.659 6.93-7.724 6.06-25.106 3.33-34.96 2.47L947.1 1329.1c-30.39-24.28-60.325-55.52 3.166-56.42-3.188-2.71-8.619-7.04-12.028-9.22-40.215-25.71-11.836-49.47 17.414-65.77 18.314-10.21 34.497-15.05 56.387-17.28z" fill="white"/>
+        <path d="M1072.7 821.2c4.03.39 6.98.79 10.04 3.3 2.03 6.48-13.6 20.97-15.67 36.37-3.89 28.83 63.95 37.61 30.57 63.2 43.15 53.65 57.27 134.69 46.26 202.02-3.83 23.38-13.28 45.44-25.45 65.68-57.56-36.61-110.11-39.94-170.83-9.05l-17.77 9.84c-38.755-69.39-33.565-162.73.808-232.8C937 948.68 944.2 937.44 952 925.6c-3.966-3.077-8.276-6.539-9.275-11.844-3.223-17.116 30.137-25.209 36.525-37.772 11.967-23.535-12.18-37.332-14.386-46.695 5.755-13.591 23.263-3.305 28.767 5.378 8.211 12.949 7.201 20.788 5.006 34.736 22.41-5.66 27.71-7.483 50.76-.112-1.62-20.186.11-39.548 23.33-45.323z" fill="white"/>
+        <path d="M1167.6 613.4c23.69-2.58 68.43 9.06 90.06 18.68 55.96 24.88 104.11 70.44 126.68 127.97 17.28 43.51 18.92 91.91 1.06 135.36-38.07 92.59-148.8 110.08-187.8 6.712-12.19-6.733-17.89-11.857-27.73-21.634-59.04-59.52-78.15-172.91-2.38-227.38-5.83-24.647-10.57-42.002-7.25-67.591C1162.25 727.1 1170.91 748.57 1197.76 770.25c2.22 8.23 3.23 13.45 4.57 21.91 15.49-15.75 51.04-4.66 30.78 34.07 11.7-14.48 14.35-35.24-2.21-47.13 11.7-21.31 6.92-37.58-10.58-51.15-10.68-35.76-33.11-47.47-64.05-63.7-4.63.81-10.31 1.16-13.67 1.58z" fill="white"/>
+        <path d="M869.9 613.4c7.52-.76 18.25-.2 25.78.48-21.61 12.04-52.66 29.14-60.16 54.84-4.41 15.1-11.94 15.23-18.31 29.02-4.53 9.81-4.49 20.97-1.07 31.09-14.95 14.11-17 32.55-2.78 48.02-2.97 6.13-6.43 14.06-5.37 21 1.952 12.76 17.212 12.455 26.745 15.474 3.475 1.1 7.451 3.95 10.488 6.051.858-7.025 1.682-13.125 2.959-20.077 8-8.365 16.679-12.614 23.14-23.685 24.736-42.386 20.678-78.032 10.976-122.311 3.529 2.672 6.99 5.432 10.381 8.279C916.42 687.99 929.68 720.48 931.64 750.21c3.302 50.27-14.78 94.36-47.06 131.99-11.04 12.05-20.55 18.65-34 27.35-2.8 12.76-8.46 24.71-16.58 34.94-15.24 18.84-39.27 32.32-63.42 34.62-36.39 3.46-67.62-18.98-88.73-46.65-32.71-42.89-26.64-99.93-11.66-150.46 8.905-30.03 23.141-53.7 43.366-77.39C745.58 648 805.84 617.6 869.9 613.4z" fill="white"/>
+        <path d="M845.7 950.6c14.88 6.32 3.59 19.98 13.27 29.05C864.5 985.2 872.2 978 878.5 978.1c11.64.25 16.24 13.92 15.06 23.71-2.84 23.43-8.1 45.95-7.58 69.72-25.67-4.03-42.35-7.76-66.26-18.77-30.45-14.19-55.93-37.22-73.12-66.08 27.73 3.34 53.31-1.5 76.4-17.9C831.3 961 837.9 954.1 845.7 950.6z" fill="white"/>
+        <path d="M1202.8 951.4c3.86 1.02 19.14 15.94 27.21 20.65 22.56 13.14 47.65 20.22 73.41 14.27-16.55 30.23-38.98 49.74-69.04 66.08-26.52 12.7-40.65 15.84-68.98 19.06-.39-10.71-1.39-21.39-3.07-31.99-1.88-12.39-8.51-35.03-6.83-44.75 2.4-13.84 17.6-17.95 27.92-11.94 7.61 4.43 14.13-13.26 12.55-19.12-1.07-3.96 2-8.75 6.72-12.25z" fill="white"/>
+        <path d="M721.1 1012.4c5.03 4.06 16.35 19.6 24.56 26.59 42.95 36.53 83.58 51.3 138.12 58.32.68 13.59 2.59 27.09 5.69 40.34-29.1 0-57.76-7.05-83.58-20.45-41.91-22.07-70.76-59.91-84.79-104.7z" fill="white"/>
+        <path d="M1328.5 1012c.31 11.48-24.36 52.78-33.02 62.6-40.16 45.54-76.97 57.86-134.16 63.5-.57-3.03-5.01-33.38-5.37-41.7-3.63-.17-7.24-.41-10.86-.74-60.42-5.45-113.7-37.68-152.09-83.66z" fill="white"/>
+        <path d="M732.9 1120.5c10.79 7.1 21.16 17.68 33.09 24.8 28.87 17.22 62.24 29.51 96.33 27.11 12.29-.87 23.03-3.55 34.8-6.25l15.91 34.22C846.1 1227 764.4 1181 732.9 1120.5z" fill="white"/>
+        <path d="M1313.9 1123l.66 1.36c-25.9 41.38-66.3 73.56-115.22 81.14-23.51 3.65-41.92 1.11-64.73-3.99 3.61-9.37 12.68-26.04 17.5-35.97 8.44 3.31 17.27 5.54 26.28 6.63 52.21 6.2 96.02-18.8 135.51-49.17z" fill="white"/>
+      </svg>
+      <div class="nav-brand-text">SkillServer<span>Gallery</span></div>
+    </a>
+    <div class="nav-links">
+      <a href="/skills" class="nav-link active">Skills</a>
+      <a href="/sub-agents" class="nav-link">Sub-agents</a>
+      <a href="/docs" class="nav-link">Docs</a>
+      <a href="/publish" class="nav-cta">+ Publish</a>
+    </div>
+  </div>
+</nav>
+
+<!-- ═══ MAIN ═══ -->
+<main class="main">
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-badge">⚡ SkillServer v0.5.0</div>
+    <h1>Browse Skills &amp; Sub-agents<br>for Your Netclaw Agents</h1>
+    <p>Discover, install, and publish reusable capabilities for your self-hosted agents. Built by the community, for the community.</p>
+  </section>
+
+  <!-- Search -->
+  <div class="search-wrap">
+    <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    <input type="text" class="search-input" placeholder="Search skills and sub-agents…" readonly>
+    <span class="search-kbd">⌘K</span>
+  </div>
+
+  <!-- Stats -->
+  <div class="stats">
+    <div class="stat">
+      <div class="stat-icon">📦</div>
+      <div>
+        <div class="stat-number">42</div>
+        <div class="stat-label">Skills</div>
+      </div>
+    </div>
+    <div class="stat">
+      <div class="stat-icon">🤖</div>
+      <div>
+        <div class="stat-number">8</div>
+        <div class="stat-label">Sub-agents</div>
+      </div>
+    </div>
+    <div class="stat">
+      <div class="stat-icon">📝</div>
+      <div>
+        <div class="stat-number">156</div>
+        <div class="stat-label">Total Files</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Recent Skills -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Recent Skills</h2>
+      <a href="/skills">View all →</a>
+    </div>
+    <div class="skill-list">
+
+      <div class="skill-card">
+        <div class="skill-icon purple">🚀</div>
+        <div class="skill-info">
+          <div class="skill-name">kubernetes-deploy</div>
+          <div class="skill-desc">Deploy pods to K8s clusters using Helm charts and Kustomize overlays</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v2.1.0</span>
+          <div class="tags">
+            <span class="tag tag-purple">Deploy</span>
+            <span class="tag tag-blue">Config</span>
+          </div>
+          <span class="skill-stars">★ 47</span>
+        </div>
+      </div>
+
+      <div class="skill-card">
+        <div class="skill-icon teal">💬</div>
+        <div class="skill-info">
+          <div class="skill-name">slack-moderation</div>
+          <div class="skill-desc">Moderation tools for Slack workspace management and channel governance</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v1.3.2</span>
+          <div class="tags">
+            <span class="tag tag-teal">Slack</span>
+            <span class="tag tag-orange">Ops</span>
+          </div>
+          <span class="skill-stars">★ 38</span>
+        </div>
+      </div>
+
+      <div class="skill-card">
+        <div class="skill-icon blue">📋</div>
+        <div class="skill-info">
+          <div class="skill-name">notion-integration</div>
+          <div class="skill-desc">Interact with Notion databases, pages, and templates programmatically</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v3.0.1</span>
+          <div class="tags">
+            <span class="tag tag-blue">Notion</span>
+            <span class="tag tag-green">Data</span>
+          </div>
+          <span class="skill-stars">★ 52</span>
+        </div>
+      </div>
+
+      <div class="skill-card">
+        <div class="skill-icon orange">🔍</div>
+        <div class="skill-info">
+          <div class="skill-name">search-citation</div>
+          <div class="skill-desc">Web research with structured citation output and source verification</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v1.8.0</span>
+          <div class="tags">
+            <span class="tag tag-orange">Search</span>
+            <span class="tag tag-purple">Research</span>
+          </div>
+          <span class="skill-stars">★ 61</span>
+        </div>
+      </div>
+
+      <div class="skill-card">
+        <div class="skill-icon pink">🧠</div>
+        <div class="skill-info">
+          <div class="skill-name">memory-management</div>
+          <div class="skill-desc">Cross-session memory tools for storing, retrieving, and organizing agent knowledge</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v2.4.3</span>
+          <div class="tags">
+            <span class="tag tag-pink">Memory</span>
+            <span class="tag tag-teal">Core</span>
+          </div>
+          <span class="skill-stars">★ 89</span>
+        </div>
+      </div>
+
+      <div class="skill-card">
+        <div class="skill-icon green">📊</div>
+        <div class="skill-info">
+          <div class="skill-name">datadog-monitoring</div>
+          <div class="skill-desc">Create dashboards, alerts, and runbooks from Datadog API interactions</div>
+        </div>
+        <div class="skill-meta">
+          <span class="skill-version">v1.1.0</span>
+          <div class="tags">
+            <span class="tag tag-green">Monitoring</span>
+            <span class="tag tag-blue">API</span>
+          </div>
+          <span class="skill-stars">★ 23</span>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Recent Sub-agents -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Recent Sub-agents</h2>
+      <a href="/sub-agents">View all →</a>
+    </div>
+    <div class="agent-grid">
+
+      <div class="agent-card">
+        <div class="agent-header">
+          <div class="agent-avatar">🔬</div>
+          <div>
+            <div class="agent-name">code-analyst</div>
+            <div class="agent-type">Specialist Agent</div>
+          </div>
+        </div>
+        <div class="agent-body">Deep codebase analysis with architectural review, dependency mapping, and automated report generation. Specializes in .NET and Node.js projects.</div>
+        <div class="agent-footer">
+          <span class="agent-badge">Main Profile</span>
+          <span class="agent-stat">⏱ 120s timeout</span>
+          <span class="agent-stat">★ 34</span>
+        </div>
+      </div>
+
+      <div class="agent-card">
+        <div class="agent-header">
+          <div class="agent-avatar">📚</div>
+          <div>
+            <div class="agent-name">research-assistant</div>
+            <div class="agent-type">Specialist Agent</div>
+          </div>
+        </div>
+        <div class="agent-body">Deep web research with citation tracking, source verification, and multi-round follow-up questions. Outputs structured summaries with inline links.</div>
+        <div class="agent-footer">
+          <span class="agent-badge">Main Profile</span>
+          <span class="agent-stat">⏱ 120s timeout</span>
+          <span class="agent-stat">★ 56</span>
+        </div>
+      </div>
+
+      <div class="agent-card">
+        <div class="agent-header">
+          <div class="agent-avatar">🎨</div>
+          <div>
+            <div class="agent-name">ui-prototyper</div>
+            <div class="agent-type">Specialist Agent</div>
+          </div>
+        </div>
+        <div class="agent-body">Generates responsive HTML mockups from wireframe descriptions. Handles brand compliance, accessibility, and cross-browser testing automatically.</div>
+        <div class="agent-footer">
+          <span class="agent-badge teal">Beta</span>
+          <span class="agent-stat">⏱ 90s timeout</span>
+          <span class="agent-stat">★ 19</span>
+        </div>
+      </div>
+
+      <div class="agent-card">
+        <div class="agent-header">
+          <div class="agent-avatar">🛡️</div>
+          <div>
+            <div class="agent-name">security-auditor</div>
+            <div class="agent-type">Specialist Agent</div>
+          </div>
+        </div>
+        <div class="agent-body">Scans codebases for vulnerabilities, misconfigurations, and dependency risks. Produces CVE-matched reports with remediation guidance.</div>
+        <div class="agent-footer">
+          <span class="agent-badge">Main Profile</span>
+          <span class="agent-stat">⏱ 180s timeout</span>
+          <span class="agent-stat">★ 41</span>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+</main>
+
+<!-- ═══ FOOTER ═══ -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">Made with <span class="heart">❤️</span> by Petabridge</div>
+    <div class="footer-links">
+      <a href="https://netclaw.dev">netclaw.dev</a>
+      <span>·</span>
+      <a href="https://petabridge.com">petabridge.com</a>
+      <span>·</span>
+      <a href="https://github.com/netclaw-dev">GitHub</a>
+    </div>
+    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/SkillServer/wwwroot/skills.html
+++ b/src/SkillServer/wwwroot/skills.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Skills - SkillServer Gallery</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="index.html" class="nav-brand">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 2L4 8v16l12 6 12-6V8L16 2z" fill="#512BD4"/><path d="M16 6l-8 4v12l8 4 8-4V10L16 6z" fill="#1a1a2e"/><path d="M14 14c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2z" fill="#00D4AA"/><path d="M12 20l4-2 4 2-4 2-4-2z" fill="#00D4AA"/><path d="M10 18l2 2-2 2-2-2 2-2z" fill="#512BD4"/><path d="M22 18l-2 2 2 2 2-2-2-2z" fill="#512BD4"/></svg>
+      <div class="nav-brand-text">SkillServer<span>Gallery</span></div>
+    </a>
+    <div class="nav-links">
+      <a href="skills.html" class="nav-link active">Skills</a>
+      <a href="subagents.html" class="nav-link">Sub-agents</a>
+      <a href="#" class="nav-link">Docs</a>
+    </div>
+  </div>
+</nav>
+
+<main class="main">
+
+  <div class="breadcrumb">
+    <a href="index.html">Home</a> <span>›</span> Skills
+  </div>
+
+  <div class="page-header">
+    <div>
+      <h1>All Skills</h1>
+      <p>Browse reusable capabilities for your agents</p>
+    </div>
+    <div class="search-wrap-inline">
+      <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="text" class="search-input" placeholder="Search skills...">
+    </div>
+  </div>
+
+  <div class="filter-bar">
+    <button class="filter-btn active">All</button>
+    <button class="filter-btn">Deploy</button>
+    <button class="filter-btn">Slack</button>
+    <button class="filter-btn">Notion</button>
+    <button class="filter-btn">Search</button>
+    <button class="filter-btn">Memory</button>
+    <button class="filter-btn">Monitoring</button>
+    <button class="filter-btn">Config</button>
+    <span class="result-count">42 skills</span>
+  </div>
+
+  <div class="skill-list">
+
+    <a href="skills/kubernetes-deploy.html" class="skill-card">
+      <div class="skill-icon purple">🚀</div>
+      <div class="skill-info">
+        <div class="skill-name">kubernetes-deploy</div>
+        <div class="skill-desc">Deploy pods to K8s clusters using Helm charts and Kustomize overlays</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v2.1.0</span>
+        <div class="tags">
+          <span class="tag tag-purple">Deploy</span>
+          <span class="tag tag-blue">Config</span>
+        </div>
+        <span class="skill-stars">★ 47</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon teal">💬</div>
+      <div class="skill-info">
+        <div class="skill-name">slack-moderation</div>
+        <div class="skill-desc">Moderation tools for Slack workspace management and channel governance</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v1.3.2</span>
+        <div class="tags">
+          <span class="tag tag-teal">Slack</span>
+          <span class="tag tag-orange">Ops</span>
+        </div>
+        <span class="skill-stars">★ 38</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon blue">📋</div>
+      <div class="skill-info">
+        <div class="skill-name">notion-integration</div>
+        <div class="skill-desc">Interact with Notion databases, pages, and templates programmatically</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v3.0.1</span>
+        <div class="tags">
+          <span class="tag tag-blue">Notion</span>
+          <span class="tag tag-green">Data</span>
+        </div>
+        <span class="skill-stars">★ 52</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon orange">🔍</div>
+      <div class="skill-info">
+        <div class="skill-name">search-citation</div>
+        <div class="skill-desc">Web research with structured citation output and source verification</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v1.8.0</span>
+        <div class="tags">
+          <span class="tag tag-orange">Search</span>
+          <span class="tag tag-purple">Research</span>
+        </div>
+        <span class="skill-stars">★ 61</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon pink">🧠</div>
+      <div class="skill-info">
+        <div class="skill-name">memory-management</div>
+        <div class="skill-desc">Cross-session memory tools for storing, retrieving, and organizing agent knowledge</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v2.4.3</span>
+        <div class="tags">
+          <span class="tag tag-pink">Memory</span>
+          <span class="tag tag-teal">Core</span>
+        </div>
+        <span class="skill-stars">★ 89</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon green">📊</div>
+      <div class="skill-info">
+        <div class="skill-name">datadog-monitoring</div>
+        <div class="skill-desc">Create dashboards, alerts, and runbooks from Datadog API interactions</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v1.1.0</span>
+        <div class="tags">
+          <span class="tag tag-green">Monitoring</span>
+          <span class="tag tag-blue">API</span>
+        </div>
+        <span class="skill-stars">★ 23</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon purple">⚙️</div>
+      <div class="skill-info">
+        <div class="skill-name">github-actions</div>
+        <div class="skill-desc">Create and manage GitHub Actions workflows, CI/CD pipelines, and automation</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v2.0.0</span>
+        <div class="tags">
+          <span class="tag tag-purple">CI</span>
+          <span class="tag tag-blue">GitHub</span>
+        </div>
+        <span class="skill-stars">★ 71</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon teal">🐳</div>
+      <div class="skill-info">
+        <div class="skill-name">docker-ops</div>
+        <div class="skill-desc">Container management, multi-stage builds, and Docker Compose orchestration</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v1.5.1</span>
+        <div class="tags">
+          <span class="tag tag-teal">Docker</span>
+          <span class="tag tag-orange">Ops</span>
+        </div>
+        <span class="skill-stars">★ 44</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon blue">📝</div>
+      <div class="skill-info">
+        <div class="skill-name">markdown-writer</div>
+        <div class="skill-desc">Generate well-structured markdown documentation with consistent formatting</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v0.9.0</span>
+        <div class="tags">
+          <span class="tag tag-blue">Docs</span>
+          <span class="tag tag-green">Writing</span>
+        </div>
+        <span class="skill-stars">★ 28</span>
+      </div>
+    </a>
+
+    <a href="#" class="skill-card">
+      <div class="skill-icon orange">🔐</div>
+      <div class="skill-info">
+        <div class="skill-name">secret-scanning</div>
+        <div class="skill-desc">Scan repositories for leaked credentials, API keys, and sensitive data</div>
+      </div>
+      <div class="skill-meta">
+        <span class="skill-version">v1.2.0</span>
+        <div class="tags">
+          <span class="tag tag-orange">Security</span>
+          <span class="tag tag-purple">Scan</span>
+        </div>
+        <span class="skill-stars">★ 63</span>
+      </div>
+    </a>
+
+  </div>
+
+  <div class="pagination">
+    <button class="page-btn disabled">←</button>
+    <button class="page-btn active">1</button>
+    <button class="page-btn">2</button>
+    <button class="page-btn">3</button>
+    <button class="page-btn">4</button>
+    <button class="page-btn">→</button>
+  </div>
+
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">Made with <span class="heart">❤️</span> by Petabridge</div>
+    <div class="footer-links">
+      <a href="https://netclaw.dev">netclaw.dev</a>
+      <span>·</span>
+      <a href="https://petabridge.com">petabridge.com</a>
+      <span>·</span>
+      <a href="https://github.com/netclaw-dev">GitHub</a>
+    </div>
+    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/SkillServer/wwwroot/skills/kubernetes-deploy.html
+++ b/src/SkillServer/wwwroot/skills/kubernetes-deploy.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>kubernetes-deploy - SkillServer Gallery</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-brand">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 2L4 8v16l12 6 12-6V8L16 2z" fill="#512BD4"/><path d="M16 6l-8 4v12l8 4 8-4V10L16 6z" fill="#1a1a2e"/><path d="M14 14c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2z" fill="#00D4AA"/><path d="M12 20l4-2 4 2-4 2-4-2z" fill="#00D4AA"/><path d="M10 18l2 2-2 2-2-2 2-2z" fill="#512BD4"/><path d="M22 18l-2 2 2 2 2-2-2-2z" fill="#512BD4"/></svg>
+      <div class="nav-brand-text">SkillServer<span>Gallery</span></div>
+    </a>
+    <div class="nav-links">
+      <a href="../skills.html" class="nav-link active">Skills</a>
+      <a href="../subagents.html" class="nav-link">Sub-agents</a>
+      <a href="#" class="nav-link">Docs</a>
+    </div>
+  </div>
+</nav>
+
+<main class="main">
+
+  <div class="breadcrumb">
+    <a href="../index.html">Home</a> <span>›</span>
+    <a href="../skills.html">Skills</a> <span>›</span>
+    kubernetes-deploy
+  </div>
+
+  <div class="detail-header">
+    <div class="detail-title">
+      <h1>kubernetes-deploy</h1>
+      <span class="detail-version">v2.1.0 <span class="latest">← latest</span></span>
+    </div>
+    <div class="tags" style="margin-bottom:16px">
+      <span class="tag tag-purple">Deploy</span>
+      <span class="tag tag-blue">Config</span>
+    </div>
+    <p class="detail-description">Deploy pods to Kubernetes clusters using Helm charts and Kustomize overlays. Supports multi-cluster deployments, rolling updates, and canary strategies. Integrates with kubectl and Helm 3 for seamless cluster operations.</p>
+    <div class="detail-meta">
+      <div class="meta-item"><span class="meta-label">Versions</span><span class="meta-value">3</span></div>
+      <div class="meta-item"><span class="meta-label">Size</span><span class="meta-value">24 KB</span></div>
+      <div class="meta-item"><span class="meta-label">Published</span><span class="meta-value">2 days ago</span></div>
+      <div class="meta-item"><span class="meta-label">Stars</span><span class="meta-value">★ 47</span></div>
+    </div>
+  </div>
+
+  <section class="section">
+    <div class="section-header">
+      <h2>SKILL.md</h2>
+      <button class="copy-btn" onclick="copyToClipboard(this, 'skill-md-content')"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy</button>
+    </div>
+    <div class="code-block"><pre id="skill-md-content">---
+name: kubernetes-deploy
+version: 2.1.0
+description: Deploy pods to K8s clusters using Helm charts and Kustomize overlays
+category: Deploy
+tags: [Deploy, Config]
+type: skill-md
+author: Petabridge
+license: Apache-2.0
+---
+
+# kubernetes-deploy
+
+## Description
+This skill enables Kubernetes deployment operations including
+Helm chart management, Kustomize overlays, and direct kubectl
+interactions.
+
+## Capabilities
+- Deploy Helm charts to target clusters
+- Manage Kustomize overlays for environment-specific configs
+- Execute rolling updates and canary deployments
+- Monitor deployment health and rollback on failure
+
+## Prerequisites
+- kubectl configured with cluster credentials
+- Helm 3 installed
+- Access to target namespace
+
+## Tools
+- kubectl deploy - Deploy resources to cluster
+- helm install - Install Helm chart
+- helm upgrade - Upgrade existing release
+- kubectl rollout - Manage rollout status</pre></div>
+  </section>
+
+  <section class="section">
+    <div class="section-header">
+      <h2>Version History</h2>
+    </div>
+    <div class="version-list">
+      <div class="version-row current">
+        <span class="version-tag latest">v2.1.0</span>
+        <span class="version-date">2 days ago</span>
+        <span class="version-size">24 KB</span>
+      </div>
+      <div class="version-row">
+        <span class="version-tag">v2.0.0</span>
+        <span class="version-date">1 month ago</span>
+        <span class="version-size">22 KB</span>
+      </div>
+      <div class="version-row">
+        <span class="version-tag">v1.0.0</span>
+        <span class="version-date">3 months ago</span>
+        <span class="version-size">18 KB</span>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+function copyToClipboard(btn, elementId) {
+  var text = document.getElementById(elementId).textContent;
+  navigator.clipboard.writeText(text).then(function() {
+    var orig = btn.innerHTML;
+    btn.classList.add('copied');
+    btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+    setTimeout(function() {
+      btn.classList.remove('copied');
+      btn.innerHTML = orig;
+    }, 2000);
+  });
+}
+</script>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">Made with <span class="heart">❤️</span> by Petabridge</div>
+    <div class="footer-links">
+      <a href="https://netclaw.dev">netclaw.dev</a>
+      <span>·</span>
+      <a href="https://petabridge.com">petabridge.com</a>
+      <span>·</span>
+      <a href="https://github.com/netclaw-dev">GitHub</a>
+    </div>
+    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/SkillServer/wwwroot/style.css
+++ b/src/SkillServer/wwwroot/style.css
@@ -1,0 +1,201 @@
+/* SkillServer Gallery - Shared Stylesheet */
+/* ── Reset ── */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --purple:#512BD4;--purple-light:#6B48E0;--purple-dark:#3D1F9E;
+  --teal:#00D4AA;--teal-dark:#00B894;
+  --bg:#1a1a2e;--bg-card:#22253a;--bg-card-hover:#2a2d4a;
+  --border:#333555;--border-light:#444666;
+  --text:#e4e6eb;--text-muted:#8a8da0;--text-dim:#6b6e82;
+  --radius:10px;--radius-sm:6px;
+}
+html{scroll-behavior:smooth}
+body{font-family:'Space Grotesk',system-ui,sans-serif;background:var(--bg);color:var(--text);line-height:1.6;min-height:100vh;display:flex;flex-direction:column;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+a{color:var(--teal);text-decoration:none;transition:color .2s}
+a:hover{color:var(--teal-dark)}
+
+/* ── NAV ── */
+.nav{position:sticky;top:0;z-index:100;background:rgba(26,26,46,.85);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 24px;display:flex;align-items:center;justify-content:space-between;height:64px}
+.nav-brand{display:flex;align-items:center;gap:12px}
+.nav-brand svg{height:28px;width:auto}
+.nav-brand-text{font-size:1.1rem;font-weight:700;letter-spacing:-.02em;color:var(--text)}
+.nav-brand-text span{color:var(--text-muted);font-weight:400;margin-left:4px}
+.nav-links{display:flex;align-items:center;gap:8px}
+.nav-link{padding:8px 16px;border-radius:var(--radius-sm);font-size:.875rem;font-weight:500;color:var(--text-muted);transition:all .2s;border:1px solid transparent}
+.nav-link:hover{color:var(--text);background:var(--bg-card);border-color:var(--border)}
+.nav-link.active{color:var(--teal);border-color:var(--teal);background:rgba(0,212,170,.08)}
+.nav-cta{padding:8px 20px;border-radius:var(--radius-sm);font-size:.875rem;font-weight:600;color:#fff;background:var(--purple);border:1px solid var(--purple);transition:all .2s}
+.nav-cta:hover{background:var(--purple-light);border-color:var(--purple-light);color:#fff}
+
+/* ── MAIN ── */
+.main{flex:1;max-width:1200px;margin:0 auto;padding:48px 24px;width:100%}
+
+/* ── HERO ── */
+.hero{text-align:center;margin-bottom:48px}
+.hero-badge{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;font-size:.75rem;font-weight:600;color:var(--teal);background:rgba(0,212,170,.1);border:1px solid rgba(0,212,170,.2);margin-bottom:20px;letter-spacing:.03em;text-transform:uppercase}
+.hero h1{font-size:2.75rem;font-weight:700;line-height:1.15;letter-spacing:-.03em;margin-bottom:12px;background:linear-gradient(135deg,var(--text) 0%,var(--text-muted) 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.hero p{font-size:1.1rem;color:var(--text-muted);max-width:560px;margin:0 auto 32px}
+
+/* ── PAGE HEADER ── */
+.page-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:32px;flex-wrap:wrap;gap:16px}
+.page-header h1{font-size:1.75rem;font-weight:700;letter-spacing:-.02em}
+.page-header p{font-size:.95rem;color:var(--text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:8px;font-size:.85rem;color:var(--text-muted);margin-bottom:24px}
+.breadcrumb a{color:var(--teal)}
+.breadcrumb a:hover{color:var(--teal-dark)}
+.breadcrumb span{color:var(--text-dim)}
+
+/* ── SEARCH ── */
+.search-wrap{max-width:600px;margin:0 auto 56px;position:relative}
+.search-wrap svg.search-icon{position:absolute;left:18px;top:50%;transform:translateY(-50%);width:20px;height:20px;color:var(--text-dim);pointer-events:none}
+.search-input{width:100%;padding:14px 20px 14px 48px;border-radius:var(--radius);border:1px solid var(--border);background:var(--bg-card);color:var(--text);font-family:inherit;font-size:1rem;outline:none;transition:border-color .2s,box-shadow .2s}
+.search-input::placeholder{color:var(--text-dim)}
+.search-input:focus{border-color:var(--purple);box-shadow:0 0 0 3px rgba(81,43,212,.25)}
+.search-kbd{position:absolute;right:16px;top:50%;transform:translateY(-50%);padding:2px 8px;border-radius:4px;font-size:.7rem;font-family:inherit;color:var(--text-dim);background:var(--bg);border:1px solid var(--border)}
+.search-wrap-inline{max-width:400px;position:relative}
+.search-wrap-inline .search-input{font-size:.875rem;padding:10px 16px 10px 40px}
+.search-wrap-inline svg.search-icon{width:16px;height:16px;left:12px}
+
+/* ── STATS ── */
+.stats{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:56px}
+.stat{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:24px;text-align:center;transition:border-color .2s,transform .2s}
+.stat:hover{border-color:var(--border-light);transform:translateY(-2px)}
+.stat-icon{font-size:1.75rem;margin-bottom:8px}
+.stat-number{font-size:2rem;font-weight:700;letter-spacing:-.02em;margin-bottom:2px;background:linear-gradient(135deg,var(--teal) 0%,var(--purple-light) 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.stat-label{font-size:.8rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:500}
+
+/* ── SECTIONS ── */
+.section{margin-bottom:56px}
+.section-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px}
+.section-header h2{font-size:1.25rem;font-weight:600;display:flex;align-items:center;gap:8px}
+.section-header h2::before{content:'';width:3px;height:20px;border-radius:2px;background:linear-gradient(180deg,var(--teal),var(--purple))}
+.section-header a{font-size:.85rem;font-weight:500;color:var(--text-muted);transition:color .2s}
+.section-header a:hover{color:var(--teal)}
+
+/* ── SKILL CARDS ── */
+.skill-list{display:flex;flex-direction:column;gap:8px}
+.skill-card{display:flex;align-items:center;gap:16px;padding:16px 20px;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);transition:all .2s;cursor:default}
+.skill-card:hover{border-color:var(--border-light);background:var(--bg-card-hover);transform:translateX(4px)}
+.skill-icon{width:40px;height:40px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0}
+.skill-icon.purple{background:rgba(81,43,212,.15);color:var(--purple-light)}
+.skill-icon.teal{background:rgba(0,212,170,.12);color:var(--teal)}
+.skill-icon.blue{background:rgba(59,130,246,.12);color:#60a5fa}
+.skill-icon.orange{background:rgba(251,146,60,.12);color:#fb923c}
+.skill-icon.pink{background:rgba(236,72,153,.12);color:#ec4899}
+.skill-icon.green{background:rgba(34,197,94,.12);color:#22c55e}
+.skill-info{flex:1;min-width:0}
+.skill-name{font-weight:600;font-size:.95rem;margin-bottom:2px}
+.skill-desc{font-size:.825rem;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.skill-meta{display:flex;align-items:center;gap:12px;flex-shrink:0}
+.skill-version{font-size:.78rem;color:var(--text-dim);font-family:'Space Grotesk',monospace;white-space:nowrap}
+.skill-stars{display:flex;align-items:center;gap:4px;font-size:.78rem;color:#f59e0b;white-space:nowrap}
+.tag{display:inline-flex;padding:3px 10px;border-radius:12px;font-size:.7rem;font-weight:600;letter-spacing:.02em}
+.tag-purple{background:rgba(81,43,212,.15);color:var(--purple-light);border:1px solid rgba(81,43,212,.25)}
+.tag-teal{background:rgba(0,212,170,.1);color:var(--teal);border:1px solid rgba(0,212,170,.2)}
+.tag-blue{background:rgba(59,130,246,.1);color:#60a5fa;border:1px solid rgba(59,130,246,.2)}
+.tag-orange{background:rgba(251,146,60,.1);color:#fb923c;border:1px solid rgba(251,146,60,.2)}
+.tag-pink{background:rgba(236,72,153,.1);color:#ec4899;border:1px solid rgba(236,72,153,.2)}
+.tag-green{background:rgba(34,197,94,.1);color:#22c55e;border:1px solid rgba(34,197,94,.2)}
+.tags{display:flex;gap:6px;flex-wrap:wrap;flex-shrink:0}
+
+/* ── SUB-AGENT CARDS ── */
+.agent-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:16px}
+.agent-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;transition:all .2s}
+.agent-card:hover{border-color:var(--border-light);background:var(--bg-card-hover);transform:translateY(-2px)}
+.agent-header{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.agent-avatar{width:44px;height:44px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1.3rem;flex-shrink:0;background:linear-gradient(135deg,var(--purple),var(--teal))}
+.agent-name{font-weight:600;font-size:1rem}
+.agent-type{font-size:.75rem;color:var(--text-muted);margin-top:1px}
+.agent-body{font-size:.85rem;color:var(--text-muted);margin-bottom:14px;line-height:1.55}
+.agent-footer{display:flex;align-items:center;gap:16px}
+.agent-badge{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:12px;font-size:.7rem;font-weight:600;background:rgba(81,43,212,.1);color:var(--purple-light);border:1px solid rgba(81,43,212,.2)}
+.agent-badge.teal{background:rgba(0,212,170,.1);color:var(--teal);border-color:rgba(0,212,170,.2)}
+.agent-stat{font-size:.75rem;color:var(--text-dim);display:flex;align-items:center;gap:4px}
+
+/* ── FILTER BAR ── */
+.filter-bar{display:flex;align-items:center;gap:12px;margin-bottom:24px;flex-wrap:wrap}
+.filter-btn{padding:6px 14px;border-radius:20px;font-size:.8rem;font-weight:500;color:var(--text-muted);background:transparent;border:1px solid var(--border);cursor:pointer;transition:all .2s}
+.filter-btn:hover{color:var(--text);border-color:var(--border-light);background:var(--bg-card)}
+.filter-btn.active{color:var(--teal);border-color:var(--teal);background:rgba(0,212,170,.08)}
+.result-count{font-size:.85rem;color:var(--text-muted);margin-left:auto}
+
+/* ── PAGINATION ── */
+.pagination{display:flex;align-items:center;justify-content:center;gap:8px;margin-top:40px}
+.page-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:var(--radius-sm);font-size:.85rem;font-weight:500;color:var(--text-muted);background:transparent;border:1px solid var(--border);cursor:pointer;transition:all .2s}
+.page-btn:hover{color:var(--text);border-color:var(--border-light);background:var(--bg-card)}
+.page-btn.active{color:var(--teal);border-color:var(--teal);background:rgba(0,212,170,.08)}
+.page-btn.disabled{opacity:.4;cursor:not-allowed}
+
+/* ── DETAIL PAGE ── */
+.detail-header{margin-bottom:32px}
+.detail-title{display:flex;align-items:center;gap:16px;margin-bottom:8px;flex-wrap:wrap}
+.detail-title h1{font-size:1.75rem;font-weight:700;letter-spacing:-.02em}
+.detail-version{font-size:.9rem;color:var(--text-muted);font-family:'Space Grotesk',monospace}
+.detail-version .latest{color:var(--teal);font-weight:600}
+.detail-description{font-size:1.05rem;color:var(--text-muted);line-height:1.6;margin-bottom:24px;max-width:700px}
+.detail-meta{display:flex;gap:24px;margin-bottom:32px;flex-wrap:wrap}
+.meta-item{display:flex;flex-direction:column;gap:2px}
+.meta-label{font-size:.7rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.06em}
+.meta-value{font-size:.9rem;font-weight:600}
+
+/* ── CODE BLOCK ── */
+.code-block{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;font-family:'Fira Code','Cascadia Code',monospace;font-size:.85rem;line-height:1.7;overflow-x:auto;color:var(--text-muted)}
+.code-block .comment{color:var(--text-dim)}
+.code-block .keyword{color:var(--purple-light)}
+.code-block .string{color:var(--teal)}
+.code-block .title{color:var(--text)}
+
+/* ── VERSION HISTORY ── */
+.version-list{display:flex;flex-direction:column;gap:4px}
+.version-row{display:flex;align-items:center;gap:16px;padding:12px 16px;border-radius:var(--radius-sm);transition:background .2s;cursor:pointer}
+.version-row:hover{background:var(--bg-card)}
+.version-row.current{background:var(--bg-card)}
+.version-tag{font-size:.85rem;font-weight:600;font-family:'Space Grotesk',monospace;min-width:80px}
+.version-tag.latest{color:var(--teal)}
+.version-date{font-size:.8rem;color:var(--text-dim)}
+.version-size{font-size:.8rem;color:var(--text-dim);margin-left:auto}
+
+/* ── FOOTER ── */
+.footer{border-top:1px solid var(--border);padding:28px 24px;text-align:center;margin-top:auto}
+.footer-inner{max-width:1200px;margin:0 auto}
+.footer-brand{font-size:.9rem;font-weight:600;color:var(--text);margin-bottom:6px}
+.footer-brand .heart{color:#ef4444}
+.footer-links{display:flex;align-items:center;justify-content:center;gap:16px;font-size:.8rem;color:var(--text-dim);margin-top:8px}
+.footer-links a{color:var(--text-muted)}
+.footer-links a:hover{color:var(--teal)}
+.footer-version{font-size:.75rem;color:var(--text-dim);margin-top:12px}
+
+/* ── COPY BUTTON ── */
+.copy-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:var(--radius-sm);font-size:.78rem;font-weight:500;color:var(--text-muted);background:var(--bg-card);border:1px solid var(--border);cursor:pointer;transition:all .2s;font-family:inherit}
+.copy-btn:hover{color:var(--text);border-color:var(--border-light);background:var(--bg-card-hover)}
+.copy-btn.copied{color:var(--teal);border-color:var(--teal);background:rgba(0,212,170,.08)}
+.copy-btn svg{width:14px;height:14px;flex-shrink:0}
+
+/* ── RESPONSIVE ── */
+@media(max-width:768px){
+  .nav-inner{height:56px}
+  .nav-links{display:none}
+  .hero h1{font-size:1.85rem}
+  .hero p{font-size:.95rem}
+  .stats{grid-template-columns:1fr;gap:12px}
+  .stat{display:flex;align-items:center;gap:16px;text-align:left;padding:16px 20px}
+  .stat-icon{margin-bottom:0;font-size:1.4rem}
+  .stat-number{font-size:1.5rem;margin-bottom:0}
+  .skill-card{flex-direction:column;align-items:flex-start;gap:10px;padding:14px 16px}
+  .skill-meta{width:100%;justify-content:space-between}
+  .agent-grid{grid-template-columns:1fr}
+  .section{margin-bottom:40px}
+  .main{padding:32px 16px}
+  .search-kbd{display:none}
+  .detail-meta{flex-direction:column;gap:12px}
+  .filter-bar{gap:8px}
+}
+@media(max-width:480px){
+  .hero h1{font-size:1.5rem}
+  .hero-badge{font-size:.65rem;padding:4px 10px}
+  .stat{padding:14px 16px}
+  .stat-number{font-size:1.25rem}
+  .agent-card{padding:16px}
+  .detail-title h1{font-size:1.4rem}
+}

--- a/src/SkillServer/wwwroot/subagents.html
+++ b/src/SkillServer/wwwroot/subagents.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sub-agents - SkillServer Gallery</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="index.html" class="nav-brand">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 2L4 8v16l12 6 12-6V8L16 2z" fill="#512BD4"/><path d="M16 6l-8 4v12l8 4 8-4V10L16 6z" fill="#1a1a2e"/><path d="M14 14c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2z" fill="#00D4AA"/><path d="M12 20l4-2 4 2-4 2-4-2z" fill="#00D4AA"/><path d="M10 18l2 2-2 2-2-2 2-2z" fill="#512BD4"/><path d="M22 18l-2 2 2 2 2-2-2-2z" fill="#512BD4"/></svg>
+      <div class="nav-brand-text">SkillServer<span>Gallery</span></div>
+    </a>
+    <div class="nav-links">
+      <a href="skills.html" class="nav-link">Skills</a>
+      <a href="subagents.html" class="nav-link active">Sub-agents</a>
+      <a href="#" class="nav-link">Docs</a>
+    </div>
+  </div>
+</nav>
+
+<main class="main">
+
+  <div class="breadcrumb">
+    <a href="index.html">Home</a> <span>›</span> Sub-agents
+  </div>
+
+  <div class="page-header">
+    <div>
+      <h1>All Sub-agents</h1>
+      <p>Specialist agents for delegated tasks</p>
+    </div>
+    <div class="search-wrap-inline">
+      <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="text" class="search-input" placeholder="Search sub-agents...">
+    </div>
+  </div>
+
+  <div class="filter-bar">
+    <button class="filter-btn active">All</button>
+    <button class="filter-btn">Main Profile</button>
+    <button class="filter-btn">Compaction</button>
+    <button class="filter-btn">Public</button>
+    <button class="filter-btn">Internal</button>
+    <span class="result-count">8 sub-agents</span>
+  </div>
+
+  <div class="agent-grid">
+
+    <a href="subagents/code-analyst.html" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">🔬</div>
+        <div>
+          <div class="agent-name">code-analyst</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Deep codebase analysis with architectural review, dependency mapping, and automated report generation. Specializes in .NET and Node.js projects.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 120s timeout</span>
+        <span class="agent-stat">★ 34</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">📚</div>
+        <div>
+          <div class="agent-name">research-assistant</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Deep web research with citation tracking, source verification, and multi-round follow-up questions. Outputs structured summaries with inline links.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 120s timeout</span>
+        <span class="agent-stat">★ 56</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">🎨</div>
+        <div>
+          <div class="agent-name">ui-prototyper</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Generates responsive HTML mockups from wireframe descriptions. Handles brand compliance, accessibility, and cross-browser testing automatically.</div>
+      <div class="agent-footer">
+        <span class="agent-badge teal">Beta</span>
+        <span class="agent-stat">⏱ 90s timeout</span>
+        <span class="agent-stat">★ 19</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">🛡️</div>
+        <div>
+          <div class="agent-name">security-auditor</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Scans codebases for vulnerabilities, misconfigurations, and dependency risks. Produces CVE-matched reports with remediation guidance.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 180s timeout</span>
+        <span class="agent-stat">★ 41</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">📊</div>
+        <div>
+          <div class="agent-name">release-manager</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Expert in software release management, git history analysis, and release note generation. Analyzes commits since last release and creates professional release notes.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 60s timeout</span>
+        <span class="agent-stat">★ 27</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">✂️</div>
+        <div>
+          <div class="agent-name">summarizer</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Summarize documents and content concisely. Handles long-form text, meeting notes, and technical documentation with extractive and abstractive methods.</div>
+      <div class="agent-footer">
+        <span class="agent-badge teal">Compaction</span>
+        <span class="agent-stat">⏱ 60s timeout</span>
+        <span class="agent-stat">★ 48</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">📋</div>
+        <div>
+          <div class="agent-name">github-issue-status</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Analyze a single GitHub issue's current status and detect changes from a previous snapshot. Reads JSON files exported by gh issue view.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 90s timeout</span>
+        <span class="agent-stat">★ 15</span>
+      </div>
+    </a>
+
+    <a href="#" class="agent-card">
+      <div class="agent-header">
+        <div class="agent-avatar">📅</div>
+        <div>
+          <div class="agent-name">notion-daily-planner</div>
+          <div class="agent-type">Specialist Agent</div>
+        </div>
+      </div>
+      <div class="agent-body">Automates daily engineering planning workflow in Notion. Extracts incomplete tasks from yesterday's plan, prompts for new items, and creates today's formatted plan.</div>
+      <div class="agent-footer">
+        <span class="agent-badge">Main Profile</span>
+        <span class="agent-stat">⏱ 60s timeout</span>
+        <span class="agent-stat">★ 22</span>
+      </div>
+    </a>
+
+  </div>
+
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">Made with <span class="heart">❤️</span> by Petabridge</div>
+    <div class="footer-links">
+      <a href="https://netclaw.dev">netclaw.dev</a>
+      <span>·</span>
+      <a href="https://petabridge.com">petabridge.com</a>
+      <span>·</span>
+      <a href="https://github.com/netclaw-dev">GitHub</a>
+    </div>
+    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/SkillServer/wwwroot/subagents/code-analyst.html
+++ b/src/SkillServer/wwwroot/subagents/code-analyst.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>code-analyst - SkillServer Gallery</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-brand">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 2L4 8v16l12 6 12-6V8L16 2z" fill="#512BD4"/><path d="M16 6l-8 4v12l8 4 8-4V10L16 6z" fill="#1a1a2e"/><path d="M14 14c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2z" fill="#00D4AA"/><path d="M12 20l4-2 4 2-4 2-4-2z" fill="#00D4AA"/><path d="M10 18l2 2-2 2-2-2 2-2z" fill="#512BD4"/><path d="M22 18l-2 2 2 2 2-2-2-2z" fill="#512BD4"/></svg>
+      <div class="nav-brand-text">SkillServer<span>Gallery</span></div>
+    </a>
+    <div class="nav-links">
+      <a href="../skills.html" class="nav-link">Skills</a>
+      <a href="../subagents.html" class="nav-link active">Sub-agents</a>
+      <a href="#" class="nav-link">Docs</a>
+    </div>
+  </div>
+</nav>
+
+<main class="main">
+
+  <div class="breadcrumb">
+    <a href="../index.html">Home</a> <span>›</span>
+    <a href="../subagents.html">Sub-agents</a> <span>›</span>
+    code-analyst
+  </div>
+
+  <div class="detail-header">
+    <div class="detail-title">
+      <h1>code-analyst</h1>
+      <span class="detail-version">v1.2.0 <span class="latest">← latest</span></span>
+    </div>
+    <p class="detail-description">Deep codebase analysis with architectural review, dependency mapping, and automated report generation. Specializes in .NET and Node.js projects. Produces structured findings for parent session review.</p>
+    <div class="detail-meta">
+      <div class="meta-item"><span class="meta-label">Role</span><span class="meta-value">Main</span></div>
+      <div class="meta-item"><span class="meta-label">Timeout</span><span class="meta-value">120s</span></div>
+      <div class="meta-item"><span class="meta-label">Visibility</span><span class="meta-value">Public</span></div>
+      <div class="meta-item"><span class="meta-label">Structured Findings</span><span class="meta-value">Yes</span></div>
+      <div class="meta-item"><span class="meta-label">Stars</span><span class="meta-value">★ 34</span></div>
+    </div>
+  </div>
+
+  <section class="section">
+    <div class="section-header">
+      <h2>agent.md</h2>
+      <button class="copy-btn" onclick="copyToClipboard(this, 'agent-md-content')"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy</button>
+    </div>
+    <div class="code-block"><pre id="agent-md-content">---
+name: code-analyst
+version: 1.2.0
+description: Deep codebase analysis with architectural review and report generation
+modelRole: Main
+timeoutSeconds: 120
+visibility: user-facing
+emitStructuredFindings: true
+author: Petabridge
+---
+
+# code-analyst
+
+## Role
+Analyze code, run commands, and review files
+
+## Capabilities
+- Static code analysis and review
+- Dependency graph mapping
+- Architecture documentation generation
+- Code quality metrics and smell detection
+
+## Specializations
+- .NET / C# - Deep analysis of ASP.NET Core, Akka.NET
+- Node.js - Express, NestJS, TypeScript projects
+
+## Tools
+- file_read - Read and analyze source files
+- shell_execute - Run analysis commands
+- structured_findings - Output review results</pre></div>
+  </section>
+
+  <section class="section">
+    <div class="section-header">
+      <h2>Version History</h2>
+    </div>
+    <div class="version-list">
+      <div class="version-row current">
+        <span class="version-tag latest">v1.2.0</span>
+        <span class="version-date">1 week ago</span>
+        <span class="version-size">8 KB</span>
+      </div>
+      <div class="version-row">
+        <span class="version-tag">v1.1.0</span>
+        <span class="version-date">1 month ago</span>
+        <span class="version-size">7 KB</span>
+      </div>
+      <div class="version-row">
+        <span class="version-tag">v1.0.0</span>
+        <span class="version-date">2 months ago</span>
+        <span class="version-size">6 KB</span>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+function copyToClipboard(btn, elementId) {
+  var text = document.getElementById(elementId).textContent;
+  navigator.clipboard.writeText(text).then(function() {
+    var orig = btn.innerHTML;
+    btn.classList.add('copied');
+    btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+    setTimeout(function() {
+      btn.classList.remove('copied');
+      btn.innerHTML = orig;
+    }, 2000);
+  });
+}
+</script>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">Made with <span class="heart">❤️</span> by Petabridge</div>
+    <div class="footer-links">
+      <a href="https://netclaw.dev">netclaw.dev</a>
+      <span>·</span>
+      <a href="https://petabridge.com">petabridge.com</a>
+      <span>·</span>
+      <a href="https://github.com/netclaw-dev">GitHub</a>
+    </div>
+    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/tests/Netclaw.SkillServer.Cli.Tests/DownloadSubAgentCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/DownloadSubAgentCommandTests.cs
@@ -50,8 +50,8 @@ public sealed class DownloadSubAgentCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         Assert.Equal(agentMd, await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken));
-        Assert.Equal("/manifest/subagents/support-agent/versions/1.0.0.json", handler.Requests[0].Path);
-        Assert.Equal("/subagents/support-agent/1.0.0/agent.md", handler.Requests[1].Path);
+        Assert.Equal("/api/v1/manifest/subagents/support-agent/versions/1.0.0.json", handler.Requests[0].Path);
+        Assert.Equal("/api/v1/subagents/support-agent/1.0.0/agent.md", handler.Requests[1].Path);
     }
 
     [Fact]
@@ -115,13 +115,13 @@ public sealed class DownloadSubAgentCommandTests : IDisposable
         Version = "1.0.0",
         Type = SubAgentArtifactTypes.AgentMd,
         Description = "test",
-        Url = "/subagents/support-agent/1.0.0/agent.md",
+        Url = "/api/v1/subagents/support-agent/1.0.0/agent.md",
         Digest = digest,
         Links = new NativeManifestSelfLinks
         {
             Self = new NativeManifestLink
             {
-                Href = "/manifest/subagents/support-agent/versions/1.0.0.json"
+                Href = "/api/v1/manifest/subagents/support-agent/versions/1.0.0.json"
             }
         }
     };

--- a/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentCommandTests.cs
@@ -49,7 +49,7 @@ public sealed class PublishSubAgentCommandTests : IDisposable
         Assert.Equal(0, exitCode);
         var request = Assert.Single(handler.Requests);
         Assert.Equal(HttpMethod.Post, request.Method);
-        Assert.Equal("/subagents", request.Path);
+        Assert.Equal("/api/v1/subagents", request.Path);
         Assert.Contains("support-agent", request.Body);
         Assert.Contains("1.0.0", request.Body);
     }
@@ -90,9 +90,9 @@ public sealed class PublishSubAgentCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         Assert.Equal(HttpMethod.Delete, handler.Requests[0].Method);
-        Assert.Equal("/subagents/support-agent/1.0.0", handler.Requests[0].Path);
+        Assert.Equal("/api/v1/subagents/support-agent/1.0.0", handler.Requests[0].Path);
         Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
-        Assert.Equal("/subagents", handler.Requests[1].Path);
+        Assert.Equal("/api/v1/subagents", handler.Requests[1].Path);
     }
 
     [Fact]

--- a/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
+++ b/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClientForwardCompatTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Text;
+using Netclaw.SkillClient;
+using Xunit;
+
+namespace SkillServer.Integration.Tests;
+
+/// <summary>
+/// Forward-compatibility hardening for the native manifest client (issue #93):
+/// a client built against today's schema must tolerate unknown resource kinds,
+/// unknown artifact types, and unrecognized fields that a newer server may emit,
+/// rather than failing to parse them.
+/// </summary>
+public sealed class ClientForwardCompatTests
+{
+    private sealed class CannedJsonHandler(string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private static SkillServerClient CreateClient(string json)
+    {
+        var httpClient = new HttpClient(new CannedJsonHandler(json))
+        {
+            BaseAddress = new Uri("http://localhost/")
+        };
+        return new SkillServerClient(httpClient);
+    }
+
+    [Fact]
+    public async Task GetManifest_WithUnknownLinkAndTopLevelField_IsTolerated()
+    {
+        const string json = """
+            {
+              "$schema": "https://netclaw.dev/manifest/v1",
+              "generatedAt": "2026-07-03T00:00:00Z",
+              "futureTopLevelField": { "anything": [1, 2, 3] },
+              "links": {
+                "self": { "href": "/manifest.json" },
+                "rfcSkills": { "href": "/.well-known/agent-skills/index.json" },
+                "skills": { "href": "/manifest/skills/index.json" },
+                "subagents": { "href": "/manifest/subagents/index.json" },
+                "futureCollection": { "href": "/manifest/future/index.json" }
+              }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var manifest = await client.GetManifestAsync(ct);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("/manifest/skills/index.json", manifest.Links.Skills.Href);
+        Assert.Equal("/manifest/subagents/index.json", manifest.Links.SubAgents.Href);
+    }
+
+    [Fact]
+    public async Task GetNativeSkillPage_WithUnknownKindAndExtraFields_IsTolerated()
+    {
+        const string json = """
+            {
+              "kind": "future-skill-page-kind",
+              "range": "0-1",
+              "unexpectedCollectionField": ["ignore", "me"],
+              "items": [
+                {
+                  "name": "example-skill",
+                  "latestVersion": "1.0.0",
+                  "versionRange": { "min": "1.0.0", "max": "1.0.0", "count": 1 },
+                  "href": "/manifest/skills/example-skill/index.json",
+                  "futureItemField": "ignored"
+                }
+              ],
+              "links": { "self": { "href": "/manifest/skills/pages/0.json" } }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var page = await client.GetNativeSkillPageAsync("manifest/skills/pages/0.json", ct);
+
+        Assert.NotNull(page);
+        // Unknown kind values round-trip as opaque strings instead of failing.
+        Assert.Equal("future-skill-page-kind", page.Kind);
+        var item = Assert.Single(page.Items);
+        Assert.Equal("example-skill", item.Name);
+        Assert.Equal("/manifest/skills/example-skill/index.json", item.Href);
+    }
+
+    [Fact]
+    public async Task GetNativeSkillVersion_WithUnknownArtifactType_IsTolerated()
+    {
+        const string json = """
+            {
+              "kind": "skill-version",
+              "artifact": {
+                "name": "example-skill",
+                "version": "1.0.0",
+                "type": "oci-image",
+                "description": "A future artifact type older clients do not understand.",
+                "url": "/skills/example-skill/1.0.0/artifact.oci",
+                "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "futureArtifactField": 42
+              },
+              "routesToSubagent": null,
+              "links": { "self": { "href": "/manifest/skills/example-skill/versions/1.0.0.json" } }
+            }
+            """;
+
+        using var client = CreateClient(json);
+        var ct = TestContext.Current.CancellationToken;
+
+        var detail = await client.GetNativeSkillVersionByHrefAsync(
+            "manifest/skills/example-skill/versions/1.0.0.json", ct);
+
+        Assert.NotNull(detail);
+        // An unrecognized artifact type is surfaced verbatim so a caller can skip
+        // it, rather than causing deserialization to throw.
+        Assert.Equal("oci-image", detail.Artifact.Type);
+        Assert.Null(detail.RoutesToSubagent);
+    }
+}

--- a/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
+++ b/tests/SkillServer.Integration.Tests/ClientForwardCompatTests.cs
@@ -49,11 +49,11 @@ public sealed class ClientForwardCompatTests
               "generatedAt": "2026-07-03T00:00:00Z",
               "futureTopLevelField": { "anything": [1, 2, 3] },
               "links": {
-                "self": { "href": "/manifest.json" },
+                "self": { "href": "/api/v1/manifest.json" },
                 "rfcSkills": { "href": "/.well-known/agent-skills/index.json" },
-                "skills": { "href": "/manifest/skills/index.json" },
-                "subagents": { "href": "/manifest/subagents/index.json" },
-                "futureCollection": { "href": "/manifest/future/index.json" }
+                "skills": { "href": "/api/v1/manifest/skills/index.json" },
+                "subagents": { "href": "/api/v1/manifest/subagents/index.json" },
+                "futureCollection": { "href": "/api/v1/manifest/future/index.json" }
               }
             }
             """;
@@ -64,8 +64,8 @@ public sealed class ClientForwardCompatTests
         var manifest = await client.GetManifestAsync(ct);
 
         Assert.NotNull(manifest);
-        Assert.Equal("/manifest/skills/index.json", manifest.Links.Skills.Href);
-        Assert.Equal("/manifest/subagents/index.json", manifest.Links.SubAgents.Href);
+        Assert.Equal("/api/v1/manifest/skills/index.json", manifest.Links.Skills.Href);
+        Assert.Equal("/api/v1/manifest/subagents/index.json", manifest.Links.SubAgents.Href);
     }
 
     [Fact]
@@ -81,11 +81,11 @@ public sealed class ClientForwardCompatTests
                   "name": "example-skill",
                   "latestVersion": "1.0.0",
                   "versionRange": { "min": "1.0.0", "max": "1.0.0", "count": 1 },
-                  "href": "/manifest/skills/example-skill/index.json",
+                  "href": "/api/v1/manifest/skills/example-skill/index.json",
                   "futureItemField": "ignored"
                 }
               ],
-              "links": { "self": { "href": "/manifest/skills/pages/0.json" } }
+              "links": { "self": { "href": "/api/v1/manifest/skills/pages/0.json" } }
             }
             """;
 
@@ -99,7 +99,7 @@ public sealed class ClientForwardCompatTests
         Assert.Equal("future-skill-page-kind", page.Kind);
         var item = Assert.Single(page.Items);
         Assert.Equal("example-skill", item.Name);
-        Assert.Equal("/manifest/skills/example-skill/index.json", item.Href);
+        Assert.Equal("/api/v1/manifest/skills/example-skill/index.json", item.Href);
     }
 
     [Fact]
@@ -113,12 +113,12 @@ public sealed class ClientForwardCompatTests
                 "version": "1.0.0",
                 "type": "oci-image",
                 "description": "A future artifact type older clients do not understand.",
-                "url": "/skills/example-skill/1.0.0/artifact.oci",
+                "url": "/api/v1/skills/example-skill/1.0.0/artifact.oci",
                 "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
                 "futureArtifactField": 42
               },
               "routesToSubagent": null,
-              "links": { "self": { "href": "/manifest/skills/example-skill/versions/1.0.0.json" } }
+              "links": { "self": { "href": "/api/v1/manifest/skills/example-skill/versions/1.0.0.json" } }
             }
             """;
 

--- a/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
+++ b/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
@@ -76,7 +76,7 @@ public sealed class NativeSyncSecurityTests
 
         content.Add(new ByteArrayContent("# Guide"u8.ToArray()), "resources", "references/guide.md");
 
-        var response = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var response = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         response.EnsureSuccessStatusCode();
         return skillName;
     }
@@ -89,7 +89,7 @@ public sealed class NativeSyncSecurityTests
         var ct = TestContext.Current.CancellationToken;
 
         using var content = CreateSubAgentUpload("no-auth-subagent", "1.0.0");
-        var response = await _fixture.HttpClient.PostAsync("/subagents", content, ct);
+        var response = await _fixture.HttpClient.PostAsync("/api/v1/subagents", content, ct);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -100,7 +100,7 @@ public sealed class NativeSyncSecurityTests
         var ct = TestContext.Current.CancellationToken;
 
         using var content = CreateSubAgentUpload("bad-key-subagent", "1.0.0");
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/subagents") { Content = content };
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/subagents") { Content = content };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sk-invalid-key");
 
         var response = await _fixture.HttpClient.SendAsync(request, ct);
@@ -113,7 +113,7 @@ public sealed class NativeSyncSecurityTests
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var response = await _fixture.HttpClient.DeleteAsync("/subagents/nonexistent/1.0.0", ct);
+        var response = await _fixture.HttpClient.DeleteAsync("/api/v1/subagents/nonexistent/1.0.0", ct);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -121,9 +121,9 @@ public sealed class NativeSyncSecurityTests
     // ---- Task 4: manifest + artifact reads stay open (auth is enabled) ---
 
     [Theory]
-    [InlineData("/manifest.json")]
-    [InlineData("/manifest/skills/index.json")]
-    [InlineData("/manifest/subagents/index.json")]
+    [InlineData("/api/v1/manifest.json")]
+    [InlineData("/api/v1/manifest/skills/index.json")]
+    [InlineData("/api/v1/manifest/subagents/index.json")]
     public async Task ManifestEndpoints_AreReadableWithoutAuth(string path)
     {
         var ct = TestContext.Current.CancellationToken;
@@ -145,15 +145,15 @@ public sealed class NativeSyncSecurityTests
         await PublishResourcefulSkillAsync(skillName, ct);
 
         using var subAgentUpload = CreateSubAgentUpload(subAgentName, "1.0.0");
-        (await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", subAgentUpload, ct))
+        (await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", subAgentUpload, ct))
             .EnsureSuccessStatusCode();
 
         string[] openArtifacts =
         [
-            $"/skills/{skillName}/1.0.0/SKILL.md",
-            $"/skills/{skillName}/1.0.0/archive.zip",
-            $"/skills/{skillName}/1.0.0/references/guide.md",
-            $"/subagents/{subAgentName}/1.0.0/agent.md"
+            $"/api/v1/skills/{skillName}/1.0.0/SKILL.md",
+            $"/api/v1/skills/{skillName}/1.0.0/archive.zip",
+            $"/api/v1/skills/{skillName}/1.0.0/references/guide.md",
+            $"/api/v1/subagents/{subAgentName}/1.0.0/agent.md"
         ];
 
         foreach (var artifact in openArtifacts)
@@ -178,7 +178,7 @@ public sealed class NativeSyncSecurityTests
         await PublishResourcefulSkillAsync(skillName, ct);
 
         var response = await _fixture.HttpClient.GetAsync(
-            $"/skills/{skillName}/1.0.0/{traversalPath}", ct);
+            $"/api/v1/skills/{skillName}/1.0.0/{traversalPath}", ct);
 
         // A traversal path must never resolve to a real file. Resource lookup is
         // by exact stored relative-path equality, so this yields a 404 rather than

--- a/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
+++ b/tests/SkillServer.Integration.Tests/NativeSyncSecurityTests.cs
@@ -1,0 +1,211 @@
+// -----------------------------------------------------------------------
+// <copyright file="NativeSyncSecurityTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Netclaw.SkillClient;
+using Xunit;
+
+namespace SkillServer.Integration.Tests;
+
+/// <summary>
+/// Security and forward-compatibility hardening for the native manifest and
+/// sub-agent sync surface (issue #93): authentication boundaries on write
+/// endpoints, open read access to manifest/artifact endpoints, path-traversal
+/// rejection on resource downloads, and digest verification on archive downloads.
+/// </summary>
+[Collection("SkillServer")]
+public sealed class NativeSyncSecurityTests
+{
+    private readonly SkillServerFixture _fixture;
+
+    public NativeSyncSecurityTests(SkillServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static MultipartFormDataContent CreateSubAgentUpload(string name, string version)
+    {
+        var agentMd = $"""
+            ---
+            name: {name}
+            description: Native sync security test sub-agent.
+            ---
+
+            You are a native-sync security test sub-agent.
+            """;
+
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent(name), "name" },
+            { new StringContent(version), "version" }
+        };
+
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(agentMd));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        form.Add(fileContent, "file", "agent.md");
+
+        return form;
+    }
+
+    private async Task<string> PublishResourcefulSkillAsync(string skillName, CancellationToken ct)
+    {
+        var skillMd = $"""
+            ---
+            name: {skillName}
+            description: Native sync security test skill.
+            ---
+
+            # Security Test Skill
+
+            See references/guide.md and scripts/setup.sh for details.
+            """;
+
+        using var content = new MultipartFormDataContent
+        {
+            { new StringContent(skillName), "name" },
+            { new StringContent("1.0.0"), "version" }
+        };
+
+        var mdContent = new ByteArrayContent(Encoding.UTF8.GetBytes(skillMd));
+        mdContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
+        content.Add(mdContent, "file", "SKILL.md");
+
+        content.Add(new ByteArrayContent("# Guide"u8.ToArray()), "resources", "references/guide.md");
+
+        var response = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        response.EnsureSuccessStatusCode();
+        return skillName;
+    }
+
+    // ---- Task 4: write endpoints require authentication -----------------
+
+    [Fact]
+    public async Task PublishSubAgent_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = CreateSubAgentUpload("no-auth-subagent", "1.0.0");
+        var response = await _fixture.HttpClient.PostAsync("/subagents", content, ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublishSubAgent_WithInvalidApiKey_Returns403()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var content = CreateSubAgentUpload("bad-key-subagent", "1.0.0");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/subagents") { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sk-invalid-key");
+
+        var response = await _fixture.HttpClient.SendAsync(request, ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteSubAgent_WithoutApiKey_Returns401()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _fixture.HttpClient.DeleteAsync("/subagents/nonexistent/1.0.0", ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ---- Task 4: manifest + artifact reads stay open (auth is enabled) ---
+
+    [Theory]
+    [InlineData("/manifest.json")]
+    [InlineData("/manifest/skills/index.json")]
+    [InlineData("/manifest/subagents/index.json")]
+    public async Task ManifestEndpoints_AreReadableWithoutAuth(string path)
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The fixture's HttpClient carries no Authorization header, yet the
+        // server is running with authentication enabled (see TestEnvironmentInitializer).
+        var response = await _fixture.HttpClient.GetAsync(path, ct);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ArtifactEndpoints_AreReadableWithoutAuth()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"sec-skill-{Guid.NewGuid():N}"[..20];
+        var subAgentName = $"sec-agent-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        using var subAgentUpload = CreateSubAgentUpload(subAgentName, "1.0.0");
+        (await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", subAgentUpload, ct))
+            .EnsureSuccessStatusCode();
+
+        string[] openArtifacts =
+        [
+            $"/skills/{skillName}/1.0.0/SKILL.md",
+            $"/skills/{skillName}/1.0.0/archive.zip",
+            $"/skills/{skillName}/1.0.0/references/guide.md",
+            $"/subagents/{subAgentName}/1.0.0/agent.md"
+        ];
+
+        foreach (var artifact in openArtifacts)
+        {
+            var response = await _fixture.HttpClient.GetAsync(artifact, ct);
+            Assert.True(
+                response.StatusCode == HttpStatusCode.OK,
+                $"Expected 200 for unauthenticated GET {artifact}, got {(int)response.StatusCode}.");
+        }
+    }
+
+    // ---- Task 3: resource downloads reject path traversal ---------------
+
+    [Theory]
+    [InlineData("..%2f..%2fSKILL.md")]
+    [InlineData("references%2f..%2f..%2f..%2fappsettings.json")]
+    public async Task SkillResourceDownload_WithTraversalPath_DoesNotEscape(string traversalPath)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"trav-skill-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        var response = await _fixture.HttpClient.GetAsync(
+            $"/skills/{skillName}/1.0.0/{traversalPath}", ct);
+
+        // A traversal path must never resolve to a real file. Resource lookup is
+        // by exact stored relative-path equality, so this yields a 404 rather than
+        // leaking bytes outside the skill's resource set.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ---- Task 2: archive downloads are digest-verified ------------------
+
+    [Fact]
+    public async Task DownloadVerifiedSkillArchive_WithTamperedDigest_Throws()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var skillName = $"digest-skill-{Guid.NewGuid():N}"[..20];
+
+        await PublishResourcefulSkillAsync(skillName, ct);
+
+        var detail = await _fixture.Client.GetNativeSkillVersionAsync(skillName, "1.0.0", ct);
+        Assert.NotNull(detail);
+        // A resourceful skill is served as a deterministic archive artifact.
+        Assert.Equal("archive", detail.Artifact.Type);
+
+        await using var destination = new MemoryStream();
+        await Assert.ThrowsAsync<InvalidDataException>(() => _fixture.Client.DownloadVerifiedArtifactAsync(
+            detail.Artifact.Url,
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            destination,
+            ct));
+    }
+}

--- a/tests/SkillServer.Integration.Tests/SkillServerClientNativeManifestTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerClientNativeManifestTests.cs
@@ -82,8 +82,8 @@ public sealed class SkillServerClientNativeManifestTests
 
         var root = await _fixture.Client.GetManifestAsync(ct);
         Assert.NotNull(root);
-        Assert.Equal("/manifest/skills/index.json", root.Links.Skills.Href);
-        Assert.Equal("/manifest/subagents/index.json", root.Links.SubAgents.Href);
+        Assert.Equal("/api/v1/manifest/skills/index.json", root.Links.Skills.Href);
+        Assert.Equal("/api/v1/manifest/subagents/index.json", root.Links.SubAgents.Href);
 
         var skillIndex = await _fixture.Client.GetNativeSkillIndexAsync(root.Links.Skills, ct);
         Assert.NotNull(skillIndex);

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -102,7 +102,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
         // List skills - should contain our skill (no auth required for reads)
@@ -115,7 +115,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Contains(index.Skills, s => s.Name == skillName);
         var indexSkill = Assert.Single(index.Skills, s => s.Name == skillName);
         Assert.Equal("skill-md", indexSkill.Type);
-        Assert.EndsWith($"/skills/{skillName}/1.0.0/SKILL.md", indexSkill.Url, StringComparison.Ordinal);
+        Assert.EndsWith($"/api/v1/skills/{skillName}/1.0.0/SKILL.md", indexSkill.Url, StringComparison.Ordinal);
 
         // Get skill versions
         var versions = await _fixture.Client.GetSkillVersionsAsync(skillName, ct);
@@ -161,15 +161,15 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var root = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeRootManifest>("/manifest.json", ct);
+        var root = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeRootManifest>("/api/v1/manifest.json", ct);
         Assert.NotNull(root);
-        Assert.Equal("/manifest.json", root.Links.Self.Href);
+        Assert.Equal("/api/v1/manifest.json", root.Links.Self.Href);
         Assert.Equal("/.well-known/agent-skills/index.json", root.Links.RfcSkills.Href);
-        Assert.Equal("/manifest/skills/index.json", root.Links.Skills.Href);
-        Assert.Equal("/manifest/subagents/index.json", root.Links.SubAgents.Href);
+        Assert.Equal("/api/v1/manifest/skills/index.json", root.Links.Skills.Href);
+        Assert.Equal("/api/v1/manifest/subagents/index.json", root.Links.SubAgents.Href);
 
         var skillIndex = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSkillCollectionIndex>(
             root.Links.Skills.Href, ct);
@@ -182,7 +182,7 @@ public sealed class SkillServerIntegrationTests
         Assert.NotNull(skillPage);
         var item = Assert.Single(skillPage.Items, i => i.Name == skillName);
         Assert.Equal("1.0.0", item.LatestVersion);
-        Assert.Equal($"/manifest/skills/{skillName}/index.json", item.Href);
+        Assert.Equal($"/api/v1/manifest/skills/{skillName}/index.json", item.Href);
 
         var identity = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSkillIdentityIndex>(
             item.Href, ct);
@@ -196,7 +196,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal("skill-version", detail.Kind);
         Assert.NotNull(detail.RoutesToSubagent);
         Assert.Equal("technical-support-diagnostician", detail.RoutesToSubagent!.Name);
-        Assert.Equal("/manifest/subagents/technical-support-diagnostician/index.json", detail.RoutesToSubagent.Href);
+        Assert.Equal("/api/v1/manifest/subagents/technical-support-diagnostician/index.json", detail.RoutesToSubagent.Href);
 
         var rfcIndex = await _fixture.Client.GetRfcIndexAsync(ct);
         Assert.NotNull(rfcIndex);
@@ -230,7 +230,7 @@ public sealed class SkillServerIntegrationTests
             """;
 
         using var content = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
         var upload = await uploadResponse.Content.ReadFromJsonAsync<SkillServer.Models.SubAgentUploadResponse>(ct);
@@ -238,14 +238,14 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal(subAgentName, upload.Name);
         Assert.Equal("1.0.0", upload.Version);
         Assert.StartsWith("sha256:", upload.Sha256);
-        Assert.EndsWith($"/subagents/{subAgentName}/1.0.0/agent.md", upload.Url, StringComparison.Ordinal);
+        Assert.EndsWith($"/api/v1/subagents/{subAgentName}/1.0.0/agent.md", upload.Url, StringComparison.Ordinal);
 
-        var list = await _fixture.HttpClient.GetFromJsonAsync<IReadOnlyList<SkillServer.Models.SubAgentSummary>>("/subagents", ct);
+        var list = await _fixture.HttpClient.GetFromJsonAsync<IReadOnlyList<SkillServer.Models.SubAgentSummary>>("/api/v1/subagents", ct);
         Assert.NotNull(list);
         Assert.Contains(list, s => s.Name == subAgentName && s.LatestVersion == "1.0.0");
 
         var versions = await _fixture.HttpClient.GetFromJsonAsync<IReadOnlyList<SkillServer.Models.SubAgentVersionSummary>>(
-            $"/subagents/{subAgentName}", ct);
+            $"/api/v1/subagents/{subAgentName}", ct);
         Assert.NotNull(versions);
         var version = Assert.Single(versions);
         Assert.Equal("agent-md", version.Type);
@@ -256,11 +256,11 @@ public sealed class SkillServerIntegrationTests
         Assert.True(version.EmitStructuredFindings);
 
         var versionDetail = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.SubAgentVersionSummary>(
-            $"/subagents/{subAgentName}/1.0.0", ct);
+            $"/api/v1/subagents/{subAgentName}/1.0.0", ct);
         Assert.NotNull(versionDetail);
         Assert.Equal(upload.Sha256, versionDetail.Sha256);
 
-        var artifactResponse = await _fixture.HttpClient.GetAsync($"/subagents/{subAgentName}/1.0.0/agent.md", ct);
+        var artifactResponse = await _fixture.HttpClient.GetAsync($"/api/v1/subagents/{subAgentName}/1.0.0/agent.md", ct);
         Assert.Equal(HttpStatusCode.OK, artifactResponse.StatusCode);
         Assert.Equal("text/markdown", artifactResponse.Content.Headers.ContentType?.MediaType);
 
@@ -292,12 +292,12 @@ public sealed class SkillServerIntegrationTests
             """;
 
         using var content = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var root = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeRootManifest>("/manifest.json", ct);
+        var root = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeRootManifest>("/api/v1/manifest.json", ct);
         Assert.NotNull(root);
-        Assert.Equal("/manifest/subagents/index.json", root.Links.SubAgents.Href);
+        Assert.Equal("/api/v1/manifest/subagents/index.json", root.Links.SubAgents.Href);
 
         var subAgentIndex = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentCollectionIndex>(
             root.Links.SubAgents.Href, ct);
@@ -311,7 +311,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal("subagent-page", subAgentPage.Kind);
         var item = Assert.Single(subAgentPage.Items, i => i.Name == subAgentName);
         Assert.Equal("1.0.0", item.LatestVersion);
-        Assert.Equal($"/manifest/subagents/{subAgentName}/index.json", item.Href);
+        Assert.Equal($"/api/v1/manifest/subagents/{subAgentName}/index.json", item.Href);
 
         var identity = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSubAgentIdentityIndex>(
             item.Href, ct);
@@ -328,9 +328,9 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal("1.0.0", detail.Version);
         Assert.Equal("agent-md", detail.Type);
         Assert.Equal("Native manifest sub-agent test.", detail.Description);
-        Assert.EndsWith($"/subagents/{subAgentName}/1.0.0/agent.md", detail.Url, StringComparison.Ordinal);
+        Assert.EndsWith($"/api/v1/subagents/{subAgentName}/1.0.0/agent.md", detail.Url, StringComparison.Ordinal);
 
-        var artifactResponse = await _fixture.HttpClient.GetAsync($"/subagents/{subAgentName}/1.0.0/agent.md", ct);
+        var artifactResponse = await _fixture.HttpClient.GetAsync($"/api/v1/subagents/{subAgentName}/1.0.0/agent.md", ct);
         Assert.Equal(HttpStatusCode.OK, artifactResponse.StatusCode);
         var artifactBytes = await artifactResponse.Content.ReadAsByteArrayAsync(ct);
         Assert.Equal(detail.Digest, ComputeSha256Digest(artifactBytes));
@@ -349,11 +349,11 @@ public sealed class SkillServerIntegrationTests
         var agentMd = $"---\nname: {subAgentName}\ndescription: Duplicate test\n---\nPrompt body";
 
         using var first = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
-        var firstResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", first, ct);
+        var firstResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", first, ct);
         Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
 
         using var second = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
-        var secondResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", second, ct);
+        var secondResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", second, ct);
         Assert.Equal(HttpStatusCode.Conflict, secondResponse.StatusCode);
     }
 
@@ -378,7 +378,7 @@ public sealed class SkillServerIntegrationTests
             var agentMd = $"---\nname: {testCase.Name}\n{testCase.Body}\n---\n{promptBody}";
             using var content = CreateSubAgentUpload(testCase.Name, "1.0.0", agentMd);
 
-            var response = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", content, ct);
+            var response = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", content, ct);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
             var error = await response.Content.ReadFromJsonAsync<SkillServer.Models.ErrorResponse>(ct);
@@ -395,14 +395,14 @@ public sealed class SkillServerIntegrationTests
         var agentMd = $"---\nname: {subAgentName}\ndescription: Delete test\n---\nPrompt body";
 
         using var content = CreateSubAgentUpload(subAgentName, "1.0.0", agentMd);
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/subagents", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/subagents", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/subagents/{subAgentName}/1.0.0", ct);
+        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/api/v1/subagents/{subAgentName}/1.0.0", ct);
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         var versions = await _fixture.HttpClient.GetFromJsonAsync<IReadOnlyList<SkillServer.Models.SubAgentVersionSummary>>(
-            $"/subagents/{subAgentName}", ct);
+            $"/api/v1/subagents/{subAgentName}", ct);
         Assert.NotNull(versions);
         Assert.Empty(versions);
     }
@@ -431,7 +431,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
 
         // Get the version to find the digest
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
@@ -469,14 +469,14 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
 
         // Verify it exists
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
         Assert.NotNull(version);
 
         // Delete it (requires auth)
-        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/skills/{skillName}/1.0.0", ct);
+        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/api/v1/skills/{skillName}/1.0.0", ct);
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         // Verify it's gone
@@ -511,7 +511,7 @@ public sealed class SkillServerIntegrationTests
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
             content.Add(fileContent, "file", "SKILL.md");
 
-            await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+            await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         }
 
         // Test pagination - get all skills then verify we can paginate
@@ -537,7 +537,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        var response = await _fixture.HttpClient.PostAsync("/skills", content, ct);
+        var response = await _fixture.HttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
@@ -546,7 +546,7 @@ public sealed class SkillServerIntegrationTests
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var response = await _fixture.HttpClient.DeleteAsync("/skills/nonexistent/1.0.0", ct);
+        var response = await _fixture.HttpClient.DeleteAsync("/api/v1/skills/nonexistent/1.0.0", ct);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
@@ -563,7 +563,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/skills");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/skills");
         request.Content = content;
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sk-invalid-key");
 
@@ -576,7 +576,7 @@ public sealed class SkillServerIntegrationTests
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var response = await _fixture.HttpClient.GetAsync("/skills", ct);
+        var response = await _fixture.HttpClient.GetAsync("/api/v1/skills", ct);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -586,7 +586,7 @@ public sealed class SkillServerIntegrationTests
         var ct = TestContext.Current.CancellationToken;
 
         // Create a new key
-        var createResponse = await _fixture.AuthenticatedHttpClient.PostAsJsonAsync("/api-keys",
+        var createResponse = await _fixture.AuthenticatedHttpClient.PostAsJsonAsync("/api/v1/api-keys",
             new { label = "test-key" }, ct);
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
@@ -600,7 +600,7 @@ public sealed class SkillServerIntegrationTests
         Assert.StartsWith("sk-", created.Key);
 
         // List keys
-        var listResponse = await _fixture.AuthenticatedHttpClient.GetAsync("/api-keys", ct);
+        var listResponse = await _fixture.AuthenticatedHttpClient.GetAsync("/api/v1/api-keys", ct);
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
 
         var keys = await listResponse.Content.ReadFromJsonAsync<IReadOnlyList<Netclaw.SkillClient.ApiKeySummary>>(jsonOptions, ct);
@@ -608,7 +608,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Contains(keys, k => k.Label == "test-key");
 
         // Delete the new key (not the bootstrap key)
-        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/api-keys/{created.Id}", ct);
+        var deleteResponse = await _fixture.AuthenticatedHttpClient.DeleteAsync($"/api/v1/api-keys/{created.Id}", ct);
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
     }
 
@@ -637,7 +637,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
 
         // Search by description keyword
         var results = await _fixture.Client.SearchSkillsAsync("kubernetes", ct: ct);
@@ -674,7 +674,7 @@ public sealed class SkillServerIntegrationTests
         var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent1));
         fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content1.Add(fileContent1, "file", "SKILL.md");
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content1, ct);
 
         // Upload v2.0.0
         var skillContent2 = $"""
@@ -692,7 +692,7 @@ public sealed class SkillServerIntegrationTests
         var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent2));
         fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content2.Add(fileContent2, "file", "SKILL.md");
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content2, ct);
 
         // Get latest - should be v2.0.0
         var latest = await _fixture.Client.GetLatestVersionAsync(skillName, ct);
@@ -705,7 +705,7 @@ public sealed class SkillServerIntegrationTests
     public async Task GetLatestVersion_NotFound_Returns404()
     {
         var ct = TestContext.Current.CancellationToken;
-        var response = await _fixture.HttpClient.GetAsync("/skills/nonexistent-skill/latest", ct);
+        var response = await _fixture.HttpClient.GetAsync("/api/v1/skills/nonexistent-skill/latest", ct);
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
@@ -731,7 +731,7 @@ public sealed class SkillServerIntegrationTests
         var fileContent1 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent1));
         fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content1.Add(fileContent1, "file", "SKILL.md");
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content1, ct);
 
         // Upload v2.0.0
         var skillContent2 = $"""
@@ -749,7 +749,7 @@ public sealed class SkillServerIntegrationTests
         var fileContent2 = new ByteArrayContent(Encoding.UTF8.GetBytes(skillContent2));
         fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content2.Add(fileContent2, "file", "SKILL.md");
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content2, ct);
 
         // Check updates - asking about v1.0.0 should show update available
         var updates = await _fixture.Client.CheckUpdatesAsync([
@@ -773,7 +773,7 @@ public sealed class SkillServerIntegrationTests
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var response = await _fixture.HttpClient.GetAsync("/api-keys", ct);
+        var response = await _fixture.HttpClient.GetAsync("/api/v1/api-keys", ct);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
@@ -801,7 +801,7 @@ public sealed class SkillServerIntegrationTests
         fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content1.Add(fileContent1, "file", "SKILL.md");
 
-        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content1, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse1.StatusCode);
 
         // Upload the same version again - should return 409 Conflict
@@ -813,7 +813,7 @@ public sealed class SkillServerIntegrationTests
         fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content2.Add(fileContent2, "file", "SKILL.md");
 
-        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content2, ct);
         Assert.Equal(HttpStatusCode.Conflict, uploadResponse2.StatusCode);
 
         // Verify the response body contains the duplicate_version error
@@ -847,7 +847,7 @@ public sealed class SkillServerIntegrationTests
         fileContent1.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content1.Add(fileContent1, "file", "SKILL.md");
 
-        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content1, ct);
+        var uploadResponse1 = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content1, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse1.StatusCode);
 
         // Upload v2.0.0 - should succeed
@@ -859,7 +859,7 @@ public sealed class SkillServerIntegrationTests
         fileContent2.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content2.Add(fileContent2, "file", "SKILL.md");
 
-        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content2, ct);
+        var uploadResponse2 = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content2, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse2.StatusCode);
 
         // Verify both versions exist
@@ -891,7 +891,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
 
         // "closed deals" should match "close deal" via porter stemming
         var results = await _fixture.Client.SearchSkillsAsync("closed deals", ct: ct);
@@ -968,7 +968,7 @@ public sealed class SkillServerIntegrationTests
         });
         content.Add(new StringContent(resourceMetadata, Encoding.UTF8, "application/json"), "resourceMetadata");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
@@ -979,20 +979,20 @@ public sealed class SkillServerIntegrationTests
         Assert.Contains("# Resource Upload Test", downloadedSkill);
 
         var refResponse = await _fixture.HttpClient.GetAsync(
-            $"/skills/{skillName}/1.0.0/references/guide.md", ct);
+            $"/api/v1/skills/{skillName}/1.0.0/references/guide.md", ct);
         Assert.Equal(HttpStatusCode.OK, refResponse.StatusCode);
         var refBody = await refResponse.Content.ReadAsStringAsync(ct);
         Assert.Contains("# Guide", refBody);
         Assert.Contains("Section One", refBody);
 
         var scriptResponse = await _fixture.HttpClient.GetAsync(
-            $"/skills/{skillName}/1.0.0/scripts/setup.sh", ct);
+            $"/api/v1/skills/{skillName}/1.0.0/scripts/setup.sh", ct);
         Assert.Equal(HttpStatusCode.OK, scriptResponse.StatusCode);
         var scriptBody = await scriptResponse.Content.ReadAsStringAsync(ct);
         Assert.Contains("setup complete", scriptBody);
 
         var toolResponse = await _fixture.HttpClient.GetAsync(
-            $"/skills/{skillName}/1.0.0/tools/check", ct);
+            $"/api/v1/skills/{skillName}/1.0.0/tools/check", ct);
         Assert.Equal(HttpStatusCode.OK, toolResponse.StatusCode);
         var toolBody = await toolResponse.Content.ReadAsStringAsync(ct);
         Assert.Contains("tool check complete", toolBody);
@@ -1002,13 +1002,13 @@ public sealed class SkillServerIntegrationTests
         var indexSkill = index.Skills.FirstOrDefault(s => s.Name == skillName);
         Assert.NotNull(indexSkill);
         Assert.Equal("archive", indexSkill!.Type);
-        Assert.EndsWith($"/skills/{skillName}/1.0.0/archive.zip", indexSkill.Url, StringComparison.Ordinal);
+        Assert.EndsWith($"/api/v1/skills/{skillName}/1.0.0/archive.zip", indexSkill.Url, StringComparison.Ordinal);
         Assert.NotEqual(version.Sha256, indexSkill.Digest);
 
         var skillMdVerified = await _fixture.Client.VerifyDigestAsync(skillName, "1.0.0", version.Sha256, ct);
         Assert.True(skillMdVerified);
 
-        var archiveResponse = await _fixture.HttpClient.GetAsync($"/skills/{skillName}/1.0.0/archive.zip", ct);
+        var archiveResponse = await _fixture.HttpClient.GetAsync($"/api/v1/skills/{skillName}/1.0.0/archive.zip", ct);
         Assert.Equal(HttpStatusCode.OK, archiveResponse.StatusCode);
         Assert.Equal("application/zip", archiveResponse.Content.Headers.ContentType?.MediaType);
 
@@ -1016,7 +1016,7 @@ public sealed class SkillServerIntegrationTests
         Assert.Equal(indexSkill.Digest, ComputeSha256Digest(archiveBytes));
 
         var nativeDetail = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.NativeSkillVersionDetail>(
-            $"/manifest/skills/{skillName}/versions/1.0.0.json", ct);
+            $"/api/v1/manifest/skills/{skillName}/versions/1.0.0.json", ct);
         Assert.NotNull(nativeDetail);
         Assert.Equal(indexSkill.Type, nativeDetail.Artifact.Type);
         Assert.Equal(indexSkill.Url, nativeDetail.Artifact.Url);
@@ -1068,7 +1068,7 @@ public sealed class SkillServerIntegrationTests
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/markdown");
         content.Add(fileContent, "file", "SKILL.md");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
         var version = await _fixture.Client.GetVersionAsync(skillName, "1.0.0", ct);
@@ -1103,7 +1103,7 @@ public sealed class SkillServerIntegrationTests
         badFile.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
         content.Add(badFile, "resources", "../etc/passwd");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
     }
 
@@ -1117,7 +1117,7 @@ public sealed class SkillServerIntegrationTests
 
         using var content = CreateResourceUploadContent(skillName, path, "exploit");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
     }
 
@@ -1134,7 +1134,7 @@ public sealed class SkillServerIntegrationTests
         });
         content.Add(new StringContent(resourceMetadata, Encoding.UTF8, "application/json"), "resourceMetadata");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
     }
 
@@ -1151,7 +1151,7 @@ public sealed class SkillServerIntegrationTests
         });
         content.Add(new StringContent(resourceMetadata, Encoding.UTF8, "application/json"), "resourceMetadata");
 
-        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/skills", content, ct);
+        var uploadResponse = await _fixture.AuthenticatedHttpClient.PostAsync("/api/v1/skills", content, ct);
         Assert.Equal(HttpStatusCode.BadRequest, uploadResponse.StatusCode);
     }
 


### PR DESCRIPTION
## Changes

- Version all API endpoints under `/api/v1/` prefix
- Wire up `UseStaticFiles()` with fallback to index.html for gallery UI
- SkillClient discovers API paths from manifest (ResolveHref helper)
- Add wwwroot to csproj for publish inclusion
- Keep `/.well-known/agent-skills/index.json` at root (RFC standard)
- 214/214 tests passing

## Gallery UI (static mockups)
- Homepage with hero, search, stats, recent skills/sub-agents
- Skills list with search, category filters, pagination
- Sub-agents list with role/visibility filters
- Skill/sub-agent detail pages with full markdown blob and copy button
- Shared stylesheet with NetClaw brand styling
- Responsive layout (desktop, tablet, mobile)

## Still TODO (next PR)
- Wire up gallery pages to fetch from API endpoints (replace mock data)
- Client-side search, pagination, detail routing