### PR TITLE
Add batch sub-agent publishing support

### DIFF
--- a/src/Netclaw.SkillServer.Cli/Commands/LintCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/LintCommand.cs
@@ -30,6 +30,12 @@ internal static class LintCommand
             return ExecuteSubAgentLint(args);
         }
 
+        if (args.Positional.Count > 0 &&
+            args.Positional[0].Equals("subagents", StringComparison.OrdinalIgnoreCase))
+        {
+            return ExecuteSubAgentsLint(args);
+        }
+
         if (args.Help || args.Positional.Count == 0)
         {
             PrintHelp();
@@ -142,6 +148,47 @@ internal static class LintCommand
         }
 
         ConsoleOutput.WriteError($"{result.Issues.Count} error(s), {result.Warnings.Count} warning(s) — lint failed");
+        return 1;
+    }
+
+    private static int ExecuteSubAgentsLint(ParsedArgs args)
+    {
+        if (args.Help || args.Positional.Count < 2)
+        {
+            PrintSubAgentsHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        var path = args.Positional[1];
+        var results = SubAgentFileScanner.ValidateDirectory(path);
+        var issues = results.SelectMany(r => r.Issues).ToList();
+        var warnings = results.SelectMany(r => r.Warnings).ToList();
+        var validSubAgents = results.Select(r => r.SubAgent).OfType<ScannedSubAgent>().ToList();
+
+        foreach (var group in validSubAgents.GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
+        {
+            issues.Add($"Duplicate sub-agent name '{group.Key}' found in input set: {string.Join(", ", group.Select(s => s.FilePath))}");
+        }
+
+        ConsoleOutput.WriteInfo($"Linting sub-agents in '{path}'...");
+        ConsoleOutput.WriteInfo($"Found {results.Count} markdown file(s).");
+        Console.WriteLine();
+
+        foreach (var issue in issues)
+            ConsoleOutput.WriteError($"✗ {issue}");
+
+        foreach (var warning in warnings)
+            ConsoleOutput.WriteWarning($"⚠ {warning}");
+
+        Console.WriteLine();
+
+        if (issues.Count == 0)
+        {
+            ConsoleOutput.WriteSuccess($"All sub-agents valid ({validSubAgents.Count} passed, {warnings.Count} warning(s))");
+            return 0;
+        }
+
+        ConsoleOutput.WriteError($"{issues.Count} error(s), {warnings.Count} warning(s) - lint failed");
         return 1;
     }
 
@@ -261,5 +308,17 @@ internal static class LintCommand
         Console.WriteLine("  - Name format matches SkillServer resource names");
         Console.WriteLine("  - Prompt body is not empty");
         Console.WriteLine("  - modelRole, visibility, timeoutSeconds, and prefillTimeoutSeconds values are valid");
+    }
+
+    private static void PrintSubAgentsHelp()
+    {
+        Console.WriteLine("Usage: skillserver lint subagents <path>");
+        Console.WriteLine();
+        Console.WriteLine("Validate all NetClaw-compatible sub-agent markdown files under a directory.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <path>    Directory containing .md sub-agent definitions");
+        Console.WriteLine();
+        Console.WriteLine("Validates each file and reports duplicate sub-agent names in the input set.");
     }
 }

--- a/src/Netclaw.SkillServer.Cli/Commands/PublishSubAgentsCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/PublishSubAgentsCommand.cs
@@ -1,0 +1,209 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishSubAgentsCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Output;
+using Netclaw.SkillServer.Cli.Publishing;
+
+namespace Netclaw.SkillServer.Cli.Commands;
+
+internal static class PublishSubAgentsCommand
+{
+    public static async Task<int> ExecuteAsync(ParsedArgs args, SkillServerClient client)
+    {
+        if (args.Help || args.Positional.Count == 0)
+        {
+            PrintHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        var path = args.Positional[0];
+        var results = SubAgentFileScanner.ValidateDirectory(path);
+        if (results.Count == 0)
+        {
+            ConsoleOutput.WriteWarning($"No sub-agent markdown files found in '{path}'.");
+            return 0;
+        }
+
+        ConsoleOutput.WriteInfo($"Scanning {path}...");
+        ConsoleOutput.WriteInfo($"Found {results.Count} sub-agent file(s).");
+        Console.WriteLine();
+
+        var publishItems = ValidateForPublish(results, args.VersionOverride);
+        foreach (var warning in publishItems.Warnings)
+            ConsoleOutput.WriteWarning($"  {warning}");
+
+        foreach (var issue in publishItems.Issues)
+            ConsoleOutput.WriteError($"  {issue}");
+
+        if (publishItems.Issues.Count > 0)
+        {
+            Console.WriteLine();
+            ConsoleOutput.WriteError($"{publishItems.Issues.Count} error(s), {publishItems.Warnings.Count} warning(s) - publish failed");
+            return 1;
+        }
+
+        int published = 0, skipped = 0, failed = 0;
+        foreach (var item in publishItems.Items)
+        {
+            if (args.DryRun)
+            {
+                ConsoleOutput.WriteWarning($"  Dry run: would publish sub-agent {item.SubAgent.Name}@{item.Version} from {item.SubAgent.FilePath}");
+                skipped++;
+                continue;
+            }
+
+            var outcome = await PublishOneAsync(client, item.SubAgent, item.Version, args.Force, args.Verbose);
+            switch (outcome.Outcome)
+            {
+                case BatchPublishOutcome.Published:
+                    ConsoleOutput.WriteSuccess($"  {item.SubAgent.Name}@{item.Version}    Published");
+                    published++;
+                    break;
+                case BatchPublishOutcome.Skipped:
+                    ConsoleOutput.WriteDim($"  {item.SubAgent.Name}@{item.Version}    Skipped ({outcome.Message})");
+                    skipped++;
+                    break;
+                case BatchPublishOutcome.Failed:
+                    ConsoleOutput.WriteError($"  {item.SubAgent.Name}@{item.Version}    Failed: {outcome.Message}");
+                    failed++;
+                    break;
+            }
+        }
+
+        Console.WriteLine();
+        ConsoleOutput.WriteInfo($"Results: {published} published, {skipped} skipped, {failed} failed");
+        return failed > 0 ? 2 : 0;
+    }
+
+    internal static BatchSubAgentPublishValidation ValidateForPublish(
+        IReadOnlyList<SubAgentLintResult> results,
+        string? defaultVersion)
+    {
+        var issues = new List<string>();
+        var warnings = new List<string>();
+        var items = new List<BatchSubAgentPublishItem>();
+
+        if (defaultVersion is not null && !SubAgentFileScanner.IsValidVersion(defaultVersion))
+            issues.Add($"Invalid --version value '{defaultVersion}'");
+
+        foreach (var result in results)
+        {
+            issues.AddRange(result.Issues);
+            warnings.AddRange(result.Warnings);
+
+            if (result.SubAgent is null)
+                continue;
+
+            var version = result.SubAgent.Version ?? defaultVersion;
+            if (!SubAgentFileScanner.IsValidVersion(version))
+            {
+                issues.Add($"{Path.GetFileName(result.SubAgent.FilePath)}: Missing publication version. Add frontmatter 'version' or pass --version <version>.");
+                continue;
+            }
+
+            items.Add(new BatchSubAgentPublishItem(result.SubAgent, version!));
+        }
+
+        foreach (var group in items.GroupBy(i => i.SubAgent.Name, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
+        {
+            issues.Add($"Duplicate sub-agent name '{group.Key}' found in input set: {string.Join(", ", group.Select(i => i.SubAgent.FilePath))}");
+        }
+
+        return new BatchSubAgentPublishValidation(items, issues, warnings);
+    }
+
+    private static async Task<BatchPublishResult> PublishOneAsync(
+        SkillServerClient client,
+        ScannedSubAgent subAgent,
+        string version,
+        bool force,
+        bool verbose)
+    {
+        try
+        {
+            if (force)
+                await DeleteExistingAsync(client, subAgent.Name, version, verbose);
+
+            await using var stream = File.OpenRead(subAgent.FilePath);
+            if (verbose)
+                ConsoleOutput.WriteDim($"  Uploading {subAgent.FilePath} ({FormatSize(stream.Length)})");
+
+            var response = await client.UploadSubAgentIfNotExistsAsync(subAgent.Name, version, stream);
+            return response is null
+                ? new BatchPublishResult(BatchPublishOutcome.Skipped, "Already published")
+                : new BatchPublishResult(BatchPublishOutcome.Published, response.Sha256);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new BatchPublishResult(BatchPublishOutcome.Failed, ex.Message);
+        }
+        catch (IOException ex)
+        {
+            return new BatchPublishResult(BatchPublishOutcome.Failed, ex.Message);
+        }
+    }
+
+    private static async Task DeleteExistingAsync(
+        SkillServerClient client,
+        string name,
+        string version,
+        bool verbose)
+    {
+        try
+        {
+            await client.DeleteSubAgentVersionAsync(name, version);
+            if (verbose)
+                ConsoleOutput.WriteDim($"  Deleted existing sub-agent {name}@{version}");
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            if (verbose)
+                ConsoleOutput.WriteDim($"  No existing sub-agent version to delete for {name}@{version}");
+        }
+    }
+
+    private static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+    };
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: skillserver publish-subagents <path> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Batch-publish all NetClaw-compatible sub-agent markdown files under <path>.");
+        Console.WriteLine("Each file must include frontmatter name and description. Publication version comes from frontmatter version or --version.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <path>                Directory containing .md sub-agent definitions");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --version <version>   Default publication version for files without frontmatter version");
+        Console.WriteLine("  --force, -f           Delete existing versions before re-publishing");
+        Console.WriteLine("  --dry-run             Validate and show what would be published without uploading");
+        Console.WriteLine("  --verbose, -v         Show detailed upload progress");
+    }
+}
+
+internal sealed record BatchSubAgentPublishItem(ScannedSubAgent SubAgent, string Version);
+
+internal sealed record BatchSubAgentPublishValidation(
+    IReadOnlyList<BatchSubAgentPublishItem> Items,
+    IReadOnlyList<string> Issues,
+    IReadOnlyList<string> Warnings);
+
+internal sealed record BatchPublishResult(BatchPublishOutcome Outcome, string Message);
+
+internal enum BatchPublishOutcome
+{
+    Published,
+    Skipped,
+    Failed
+}

--- a/src/Netclaw.SkillServer.Cli/Program.cs
+++ b/src/Netclaw.SkillServer.Cli/Program.cs
@@ -78,6 +78,7 @@ static async Task<int> DispatchAsync(ParsedArgs parsedArgs, SkillServerClient cl
     {
         "publish" => await PublishCommand.ExecuteAsync(parsedArgs, client),
         "publish-subagent" => await PublishSubAgentCommand.ExecuteAsync(parsedArgs, client),
+        "publish-subagents" => await PublishSubAgentsCommand.ExecuteAsync(parsedArgs, client),
         "download-subagent" => await DownloadSubAgentCommand.ExecuteAsync(parsedArgs, client),
         "publish-all" => await PublishAllCommand.ExecuteAsync(parsedArgs, client),
         "delete" => await DeleteCommand.ExecuteAsync(parsedArgs, client),
@@ -121,6 +122,7 @@ static void PrintHelp()
     Console.WriteLine("Commands:");
     Console.WriteLine("  publish <path>            Publish a skill directory to the server");
     Console.WriteLine("  publish-subagent <path>   Publish a sub-agent markdown file to the server");
+    Console.WriteLine("  publish-subagents <path>  Batch-publish sub-agent markdown files");
     Console.WriteLine("  download-subagent <n> <v> <path> Download a verified sub-agent artifact");
     Console.WriteLine("  publish-all <path>        Batch-publish all skills in a directory");
     Console.WriteLine("  lint <path>               Validate skills or sub-agents (no auth required)");

--- a/src/Netclaw.SkillServer.Cli/Publishing/SubAgentFileScanner.cs
+++ b/src/Netclaw.SkillServer.Cli/Publishing/SubAgentFileScanner.cs
@@ -11,6 +11,7 @@ namespace Netclaw.SkillServer.Cli.Publishing;
 internal sealed record ScannedSubAgent(
     string FilePath,
     string Name,
+    string? Version,
     string Description,
     string Body,
     string ModelRole,
@@ -29,6 +30,8 @@ internal static partial class SubAgentFileScanner
     private static readonly HashSet<string> KnownFields = new(StringComparer.OrdinalIgnoreCase)
     {
         "name",
+        "version",
+        "metadata.version",
         "description",
         "tools",
         "modelRole",
@@ -100,6 +103,10 @@ internal static partial class SubAgentFileScanner
         var timeoutSeconds = ParseTimeout(fields.GetValueOrDefault("timeoutSeconds"), "timeoutSeconds", 60, 5, 600, issues, displayName);
         var prefillTimeoutSeconds = ParseOptionalTimeout(fields.GetValueOrDefault("prefillTimeoutSeconds"), "prefillTimeoutSeconds", 5, 3600, issues, displayName);
         var emitStructuredFindings = ParseBool(fields.GetValueOrDefault("emitStructuredFindings"), "emitStructuredFindings", false, issues, displayName);
+        var version = NormalizeVersion(
+            fields.GetValueOrDefault("version") ?? fields.GetValueOrDefault("metadata.version"),
+            issues,
+            displayName);
 
         if (issues.Count > 0)
             return new SubAgentLintResult(issues, warnings, null);
@@ -110,6 +117,7 @@ internal static partial class SubAgentFileScanner
             new ScannedSubAgent(
                 Path.GetFullPath(filePath),
                 name!,
+                version,
                 description!,
                 body,
                 modelRole,
@@ -117,6 +125,20 @@ internal static partial class SubAgentFileScanner
                 prefillTimeoutSeconds,
                 visibility,
                 emitStructuredFindings));
+    }
+
+    public static IReadOnlyList<SubAgentLintResult> ValidateDirectory(string directoryPath)
+    {
+        var dir = Path.GetFullPath(directoryPath);
+        if (!Directory.Exists(dir))
+        {
+            return [new SubAgentLintResult([$"{Path.GetFileName(dir)}: Directory does not exist"], [], null)];
+        }
+
+        return Directory.EnumerateFiles(dir, "*.md", SearchOption.AllDirectories)
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .Select(ValidateFile)
+            .ToList();
     }
 
     private static Dictionary<string, string> ParseFrontmatter(string yaml, List<string> warnings, string displayName)
@@ -241,6 +263,18 @@ internal static partial class SubAgentFileScanner
         return !string.IsNullOrWhiteSpace(version) &&
                version.Length <= 64 &&
                version.All(c => char.IsLetterOrDigit(c) || c == '.' || c == '-' || c == '+');
+    }
+
+    private static string? NormalizeVersion(string? value, List<string> issues, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (IsValidVersion(value))
+            return value;
+
+        issues.Add($"{displayName}: Invalid 'version' format '{value}' - must be 1-64 alphanumeric characters, dots, hyphens, or plus signs");
+        return null;
     }
 
     internal static bool IsValidName(string? name)

--- a/src/SkillServer/Data/SkillRepository.cs
+++ b/src/SkillServer/Data/SkillRepository.cs
@@ -365,7 +365,6 @@ public sealed class SkillRepository
             ORDER BY
                 CASE WHEN s.name = @query THEN 0
                      WHEN s.name LIKE @query || '%' THEN 1
-                     WHEN skills_fts MATCH 'name:' || @ftsQuery THEN 2
                      ELSE 3 END,
                 rank
             """;

--- a/src/SkillServer/Data/SkillRepository.cs
+++ b/src/SkillServer/Data/SkillRepository.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SkillRepository.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -362,7 +362,12 @@ public sealed class SkillRepository
             JOIN skills s ON s.id = skills_fts.rowid
             JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_latest = 1
             WHERE skills_fts MATCH @ftsQuery
-            ORDER BY rank
+            ORDER BY
+                CASE WHEN s.name = @query THEN 0
+                     WHEN s.name LIKE @query || '%' THEN 1
+                     WHEN skills_fts MATCH 'name:' || @ftsQuery THEN 2
+                     ELSE 3 END,
+                rank
             """;
 
         if (take.HasValue)
@@ -370,7 +375,7 @@ public sealed class SkillRepository
         if (skip.HasValue)
             sql += $" OFFSET {skip.Value}";
 
-        var versions = await connection.QueryAsync<SkillVersionWithMetadata>(sql, new { ftsQuery });
+        var versions = await connection.QueryAsync<SkillVersionWithMetadata>(sql, new { ftsQuery, query });
         return versions.ToList();
     }
 

--- a/src/SkillServer/wwwroot/index.html
+++ b/src/SkillServer/wwwroot/index.html
@@ -35,7 +35,8 @@
 
   <div class="search-wrap">
     <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-    <input type="text" class="search-input" id="search" placeholder="Search skills...">
+    <input type="text" class="search-input" id="search" placeholder="Search skills and press Enter..." aria-label="Search skills, press Enter to submit">
+    <kbd class="search-kbd">↵</kbd>
   </div>
 
   <div class="stats">

--- a/src/SkillServer/wwwroot/js/router.js
+++ b/src/SkillServer/wwwroot/js/router.js
@@ -17,6 +17,18 @@ export function getSkillName() {
     return null;
 }
 
+export function getSkillVersion() {
+    const segments = getPathSegments();
+    if (segments.length >= 4 && segments[0] === 'skills' && segments[2] === 'v') {
+        return decodeURIComponent(segments[3]);
+    }
+    return null;
+}
+
+export function isVersionDetail() {
+    return getSkillVersion() !== null;
+}
+
 export function getSubAgentName() {
     const segments = getPathSegments();
     if (segments.length >= 2 && segments[0] === 'subagents') {

--- a/src/SkillServer/wwwroot/skills/index.html
+++ b/src/SkillServer/wwwroot/skills/index.html
@@ -45,13 +45,14 @@
 
 <script type="module">
 import { fetchSkills, fetchSkillVersions, fetchSkillMd } from '/js/api.js';
-import { getSkillName } from '/js/router.js';
+import { getSkillName, getSkillVersion } from '/js/router.js';
 
 const app = document.getElementById('app');
 const skillName = getSkillName();
+const requestedVersion = getSkillVersion();
 
 if (skillName) {
-    await renderDetail(skillName);
+    await renderDetail(skillName, requestedVersion);
 } else {
     await renderListing();
 }
@@ -89,29 +90,33 @@ async function renderListing() {
     }
 }
 
-async function renderDetail(name) {
+async function renderDetail(name, version) {
     document.title = `${name} - SkillServer Gallery`;
     try {
         const versions = await fetchSkillVersions(name);
-        const latest = versions.find(v => v.isLatest) || versions[0];
-        const skillMd = await fetchSkillMd(name, latest.version);
+        const targetVersion = version 
+            ? (versions.find(v => v.version === version) || versions.find(v => v.isLatest) || versions[0])
+            : (versions.find(v => v.isLatest) || versions[0]);
+        document.title = `${name}${version ? ' v' + targetVersion.version : ''} - SkillServer Gallery`;
+        const skillMd = await fetchSkillMd(name, targetVersion.version);
         app.innerHTML = `
             <div class="breadcrumb">
                 <a href="/">Home</a> <span>›</span>
                 <a href="/skills/">Skills</a> <span>›</span>
-                ${name}
+                <a href="/skills/${encodeURIComponent(name)}/">${name}</a>
+                ${version ? `<span>›</span><span>v${targetVersion.version}</span>` : ''}
             </div>
             <div class="detail-header">
                 <div class="detail-title">
                     <h1>${name}</h1>
-                    <span class="detail-version">v${latest.version} ${latest.isLatest ? '<span class="latest">← latest</span>' : ''}</span>
+                    <span class="detail-version">v${targetVersion.version} ${targetVersion.isLatest ? '<span class="latest">← latest</span>' : ''}</span>
                 </div>
-                ${latest.category ? `<div class="tags" style="margin-bottom:16px"><span class="tag">${latest.category}</span></div>` : ''}
-                <p class="detail-description">${latest.description || ''}</p>
+                ${targetVersion.category ? `<div class="tags" style="margin-bottom:16px"><span class="tag">${targetVersion.category}</span></div>` : ''}
+                <p class="detail-description">${targetVersion.description || ''}</p>
                 <div class="detail-meta">
                     <div class="meta-item"><span class="meta-label">Versions</span><span class="meta-value">${versions.length}</span></div>
-                    <div class="meta-item"><span class="meta-label">Size</span><span class="meta-value">${formatBytes(latest.sizeBytes)}</span></div>
-                    <div class="meta-item"><span class="meta-label">Published</span><span class="meta-value">${formatDate(latest.publishedAt)}</span></div>
+                    <div class="meta-item"><span class="meta-label">Size</span><span class="meta-value">${formatBytes(targetVersion.sizeBytes)}</span></div>
+                    <div class="meta-item"><span class="meta-label">Published</span><span class="meta-value">${formatDate(targetVersion.publishedAt)}</span></div>
                 </div>
             </div>
             <section class="section">
@@ -126,11 +131,11 @@ async function renderDetail(name) {
                 </div>
                 <div class="version-list">
                     ${versions.map(v => `
-                        <div class="version-row ${v.isLatest ? 'current' : ''}">
-                            <span class="version-tag ${v.isLatest ? 'latest' : ''}">v${v.version}</span>
+                        <a href="/skills/${encodeURIComponent(name)}/v/${encodeURIComponent(v.version)}/" class="version-row ${v.version === targetVersion.version ? 'current' : ''} ${v.isLatest && v.version !== targetVersion.version ? 'latest-link' : ''}" role="button" tabindex="0">
+                            <span class="version-tag ${v.version === targetVersion.version && v.isLatest ? 'latest' : ''}">v${v.version}</span>
                             <span class="version-date">${formatDate(v.publishedAt)}</span>
                             <span class="version-size">${formatBytes(v.sizeBytes)}</span>
-                        </div>
+                        </a>
                     `).join('')}
                 </div>
             </section>

--- a/src/SkillServer/wwwroot/style.css
+++ b/src/SkillServer/wwwroot/style.css
@@ -75,7 +75,7 @@ a:hover{color:var(--teal-dark)}
 
 /* ── SKILL CARDS ── */
 .skill-list{display:flex;flex-direction:column;gap:8px}
-.skill-card{display:flex;align-items:center;gap:16px;padding:16px 20px;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);transition:all .2s;cursor:default}
+.skill-card{display:flex;align-items:center;gap:16px;padding:16px 20px;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);transition:all .2s;cursor:pointer}
 .skill-card:hover{border-color:var(--border-light);background:var(--bg-card-hover);transform:translateX(4px)}
 .skill-icon{width:40px;height:40px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0}
 .skill-icon.purple{background:rgba(81,43,212,.15);color:var(--purple-light)}
@@ -148,9 +148,10 @@ a:hover{color:var(--teal-dark)}
 
 /* ── VERSION HISTORY ── */
 .version-list{display:flex;flex-direction:column;gap:4px}
-.version-row{display:flex;align-items:center;gap:16px;padding:12px 16px;border-radius:var(--radius-sm);transition:background .2s;cursor:pointer}
-.version-row:hover{background:var(--bg-card)}
+.version-row{display:flex;align-items:center;gap:16px;padding:12px 16px;border-radius:var(--radius-sm);transition:background .2s;cursor:pointer;color:var(--text)}
+.version-row:hover{background:var(--bg-card);color:var(--text)}
 .version-row.current{background:var(--bg-card)}
+.version-row.latest-link .version-tag::after{content:" (latest)";font-size:.7rem;color:var(--teal);font-weight:500}
 .version-tag{font-size:.85rem;font-weight:600;font-family:'Space Grotesk',monospace;min-width:80px}
 .version-tag.latest{color:var(--teal)}
 .version-date{font-size:.8rem;color:var(--text-dim)}

--- a/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
@@ -98,6 +98,25 @@ public sealed class CliArgsParserTests
     }
 
     [Fact]
+    public void Parse_PublishSubAgentsCommand_WithAllFlags()
+    {
+        var result = CliArgsParser.Parse([
+            "publish-subagents", "./agents",
+            "--version", "1.0.0",
+            "--force",
+            "--dry-run",
+            "--verbose"
+        ]);
+
+        Assert.Equal("publish-subagents", result.Command);
+        Assert.Equal("./agents", result.Positional[0]);
+        Assert.Equal("1.0.0", result.VersionOverride);
+        Assert.True(result.Force);
+        Assert.True(result.DryRun);
+        Assert.True(result.Verbose);
+    }
+
+    [Fact]
     public void Parse_DownloadSubAgentCommand_WithFlags()
     {
         var result = CliArgsParser.Parse([

--- a/tests/Netclaw.SkillServer.Cli.Tests/LintCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/LintCommandTests.cs
@@ -392,5 +392,43 @@ public sealed class LintCommandTests : IDisposable
         Assert.Equal(0, result); // warnings don't fail
     }
 
+    [Fact]
+    public async Task ExecuteAsync_SubAgentsDirectoryWithDuplicateNames_Returns1()
+    {
+        CreateSubAgentFile("one.md", "support-agent");
+        CreateSubAgentFile("two.md", "support-agent");
+
+        var args = new ParsedArgs { Positional = ["subagents", _tempDir] };
+
+        var result = await LintCommand.ExecuteAsync(args);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidSubAgentsDirectory_Returns0()
+    {
+        CreateSubAgentFile("support.md", "support-agent");
+        CreateSubAgentFile("review.md", "review-agent");
+
+        var args = new ParsedArgs { Positional = ["subagents", _tempDir] };
+
+        var result = await LintCommand.ExecuteAsync(args);
+
+        Assert.Equal(0, result);
+    }
+
     #endregion
+
+    private void CreateSubAgentFile(string fileName, string name)
+    {
+        File.WriteAllText(Path.Combine(_tempDir, fileName), $"""
+            ---
+            name: {name}
+            description: Diagnose support issues.
+            ---
+
+            You are a support diagnostician.
+            """);
+    }
 }

--- a/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
@@ -65,6 +65,27 @@ public sealed class ProgramDispatchTests : IDisposable
     }
 
     [Fact]
+    public async Task LintSubAgents_DoesNotRequireServerUrl()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var agentPath = Path.Combine(_tempDir, "support-agent.md");
+        await File.WriteAllTextAsync(agentPath, """
+            ---
+            name: support-agent
+            description: Diagnose support issues.
+            ---
+
+            You are a support diagnostician.
+            """, ct);
+
+        var result = await RunCliAsync(["lint", "subagents", _tempDir], ct);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Server URL not configured", result.StdErr);
+        Assert.DoesNotContain("Server URL not configured", result.StdOut);
+    }
+
+    [Fact]
     public async Task List_RequiresServerUrl()
     {
         var ct = TestContext.Current.CancellationToken;

--- a/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentsCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/PublishSubAgentsCommandTests.cs
@@ -1,0 +1,185 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishSubAgentsCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Commands;
+using Netclaw.SkillServer.Cli.Publishing;
+using Xunit;
+
+namespace Netclaw.SkillServer.Cli.Tests;
+
+public sealed class PublishSubAgentsCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PublishSubAgentsCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"skillserver-subagents-publish-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DryRun_DoesNotCallServer()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        CreateSubAgentFile("support-agent", version: "1.0.0");
+
+        var exitCode = await PublishSubAgentsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [_tempDir], DryRun = true },
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultVersion_PublishesFilesWithoutFrontmatterVersion()
+    {
+        var handler = new RecordingHandler(JsonResponse("support-agent", "1.2.3"));
+        using var client = CreateClient(handler);
+        CreateSubAgentFile("support-agent");
+
+        var exitCode = await PublishSubAgentsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [_tempDir], VersionOverride = "1.2.3" },
+            client);
+
+        Assert.Equal(0, exitCode);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/api/v1/subagents", request.Path);
+        Assert.Contains("support-agent", request.Body, StringComparison.Ordinal);
+        Assert.Contains("1.2.3", request.Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FrontmatterVersion_OverridesDefaultVersion()
+    {
+        var handler = new RecordingHandler(JsonResponse("support-agent", "2.0.0"));
+        using var client = CreateClient(handler);
+        CreateSubAgentFile("support-agent", version: "2.0.0");
+
+        var exitCode = await PublishSubAgentsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [_tempDir], VersionOverride = "1.0.0" },
+            client);
+
+        Assert.Equal(0, exitCode);
+        var request = Assert.Single(handler.Requests);
+        Assert.Contains("2.0.0", request.Body, StringComparison.Ordinal);
+        Assert.DoesNotContain("1.0.0", request.Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DuplicateNames_ReturnsErrorBeforePublishing()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        CreateSubAgentFile("support-agent", fileName: "one.md", version: "1.0.0");
+        CreateSubAgentFile("support-agent", fileName: "two.md", version: "1.0.1");
+
+        var exitCode = await PublishSubAgentsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = [_tempDir] },
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public void ValidateForPublish_MissingVersion_ReturnsIssue()
+    {
+        var path = CreateSubAgentFile("support-agent");
+        var results = new[] { SubAgentFileScanner.ValidateFile(path) };
+
+        var validation = PublishSubAgentsCommand.ValidateForPublish(results, defaultVersion: null);
+
+        Assert.Empty(validation.Items);
+        Assert.Contains(validation.Issues, issue => issue.Contains("Missing publication version", StringComparison.Ordinal));
+    }
+
+    private string CreateSubAgentFile(string name, string? fileName = null, string? version = null)
+    {
+        var path = Path.Combine(_tempDir, fileName ?? $"{name}.md");
+        var versionLine = version is null ? "" : $"version: {version}\n";
+        File.WriteAllText(path, $"""
+            ---
+            name: {name}
+            {versionLine}description: Diagnose support issues.
+            modelRole: Main
+            timeoutSeconds: 120
+            visibility: internal
+            ---
+
+            You are a support diagnostician.
+            """);
+        return path;
+    }
+
+    private static SkillServerClient CreateClient(HttpMessageHandler handler)
+    {
+        return new SkillServerClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.test/")
+        });
+    }
+
+    private static HttpResponseMessage JsonResponse(string name, string version)
+    {
+        var response = new SubAgentUploadResponse
+        {
+            Name = name,
+            Version = version,
+            Sha256 = "sha256:abc",
+            Url = $"https://example.test/subagents/{name}/{version}/agent.md"
+        };
+        var json = JsonSerializer.Serialize(response, SkillServerClientJsonContext.Default.SubAgentUploadResponse);
+        return new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri?.AbsolutePath ?? "",
+                body));
+
+            return _responses.Count == 0
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : _responses.Dequeue();
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Path, string Body);
+}

--- a/tests/Netclaw.SkillServer.Cli.Tests/SubAgentFileScannerTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/SubAgentFileScannerTests.cs
@@ -32,11 +32,65 @@ public sealed class SubAgentFileScannerTests
         Assert.Empty(result.Warnings);
         Assert.NotNull(result.SubAgent);
         Assert.Equal("support-agent", result.SubAgent.Name);
+        Assert.Null(result.SubAgent.Version);
         Assert.Equal("Main", result.SubAgent.ModelRole);
         Assert.Equal(120, result.SubAgent.TimeoutSeconds);
         Assert.Equal(30, result.SubAgent.PrefillTimeoutSeconds);
         Assert.Equal("internal", result.SubAgent.Visibility);
         Assert.True(result.SubAgent.EmitStructuredFindings);
+    }
+
+    [Fact]
+    public void ValidateContent_VersionFrontmatter_ReturnsScannedVersion()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            version: 1.2.3
+            description: Diagnose support issues.
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Empty(result.Issues);
+        Assert.NotNull(result.SubAgent);
+        Assert.Equal("1.2.3", result.SubAgent.Version);
+    }
+
+    [Fact]
+    public void ValidateContent_MetadataVersionFrontmatter_ReturnsScannedVersion()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            metadata.version: 1.2.3
+            description: Diagnose support issues.
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Empty(result.Issues);
+        Assert.NotNull(result.SubAgent);
+        Assert.Equal("1.2.3", result.SubAgent.Version);
+    }
+
+    [Fact]
+    public void ValidateContent_InvalidVersionFrontmatter_ReportsIssue()
+    {
+        var result = SubAgentFileScanner.ValidateContent("agent.md", "/tmp/agent.md", """
+            ---
+            name: support-agent
+            version: bad/version
+            description: Diagnose support issues.
+            ---
+
+            Prompt body.
+            """);
+
+        Assert.Null(result.SubAgent);
+        Assert.Contains(result.Issues, issue => issue.Contains("Invalid 'version' format", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add batch sub-agent linting and publishing commands
- support per-file version frontmatter and default --version for sub-agent batch publishing
- preserve UI search/version navigation fixes and deterministic SQLite FTS search ordering

## Validation
- dotnet build -c Release
- dotnet test -c Release
- pwsh scripts/Add-FileHeaders.ps1 -Verify
- dotnet slopwatch analyze