### PR TITLE
Split release version parsing into core/suffix

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,15 @@
 ######################################################################
 $releaseNotes = Get-ReleaseNotes -MarkdownFile (Join-Path -Path $PSScriptRoot -ChildPath "RELEASE_NOTES.md")
 
+Write-Output "Updating release metadata to $($releaseNotes.Version)"
+
+if ($releaseNotes.VersionSuffix.Length -gt 0) {
+    Write-Output "Release suffix: $($releaseNotes.VersionSuffix)"
+} else {
+    Write-Output "Release is stable: no prerelease suffix"
+}
+
 # inject release notes into Directory.Buil
 UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath (Join-Path -Path $PSScriptRoot -ChildPath "Directory.Build.props")
 
-Write-Output "Added release notes $releaseNotes"
+Write-Output "Updated Directory.Build.props from $($releaseNotes.Version)"

--- a/scripts/bumpVersion.ps1
+++ b/scripts/bumpVersion.ps1
@@ -11,9 +11,28 @@ function UpdateVersionAndReleaseNotes {
     $xmlContent = New-Object XML
     $xmlContent.Load($XmlFilePath)
 
-    # Update VersionPrefix and PackageReleaseNotes
+    if (-not $ReleaseNotesResult.VersionCore) {
+        throw "Get-ReleaseNotes did not return VersionCore for metadata update"
+    }
+
+    # Update VersionPrefix/VersionSuffix and PackageReleaseNotes
     $versionPrefixElement = $xmlContent.SelectSingleNode("//VersionPrefix")
-    $versionPrefixElement.InnerText = $ReleaseNotesResult.Version
+    if (-not $versionPrefixElement) {
+        throw "Directory.Build.props is missing VersionPrefix"
+    }
+
+    $versionPrefixElement.InnerText = $ReleaseNotesResult.VersionCore
+
+    $versionSuffixElement = $xmlContent.SelectSingleNode("//VersionSuffix")
+    if (-not $versionSuffixElement) {
+        throw "Directory.Build.props is missing VersionSuffix"
+    }
+
+    $versionSuffixElement.InnerText = $ReleaseNotesResult.VersionSuffix
+
+    if ($ReleaseNotesResult.VersionSuffix.Length -eq 0) {
+        Write-Output "Updated release version suffix to empty (stable release)"
+    }
 
     $packageReleaseNotesElement = $xmlContent.SelectSingleNode("//PackageReleaseNotes")
     $packageReleaseNotesElement.InnerText = $ReleaseNotesResult.ReleaseNotes

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -4,8 +4,12 @@ function Get-ReleaseNotes {
         [string]$MarkdownFile
     )
 
-    # Read markdown file content
-    $lines = Get-Content -Path $MarkdownFile
+    # Read markdown file content explicitly as UTF-8 to avoid platform-dependent defaults.
+    # Fall back to UTF-16 only if the UTF-8 read returns no lines.
+    $lines = [System.IO.File]::ReadAllLines($MarkdownFile, [System.Text.Encoding]::UTF8)
+    if (-not $lines -or $lines.Count -eq 0) {
+        $lines = [System.IO.File]::ReadAllLines($MarkdownFile, [System.Text.Encoding]::Unicode)
+    }
 
     $versionPattern = '^(?<core>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))(?:-(?<suffix>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
 
@@ -41,38 +45,77 @@ function Get-ReleaseNotes {
 
         return $Line
     }
+
+    function Get-ReleaseHeaderCandidate {
+        param(
+            [Parameter()]
+            [AllowEmptyString()]
+            [string]$Line
+        )
+
+        $candidate = Get-LeadingNoiseFreeText -Line $Line
+        $headerIndex = $candidate.IndexOf('####')
+        if ($headerIndex -ge 0) {
+            return $candidate.Substring($headerIndex)
+        }
+
+        return $null
+    }
+
+    function Get-ReleaseHeaderData {
+        param(
+            [Parameter()]
+            [AllowEmptyString()]
+            [string]$Line
+        )
+
+        $candidate = Get-ReleaseHeaderCandidate -Line $Line
+        if (-not $candidate) {
+            return $null
+        }
+
+        $normalizedHeaderLine = $candidate -replace "^####\s*", ""
+        $normalizedHeaderLine = $normalizedHeaderLine -replace "\s*####\s*$", ""
+
+        $headerParts = $normalizedHeaderLine -split " ", 2
+        $versionText = $headerParts[0]
+
+        $versionMatch = [regex]::Match($versionText, $versionPattern)
+        if (-not $versionMatch.Success) {
+            return $null
+        }
+
+        return [PSCustomObject]@{
+            HeaderParts = $headerParts
+            VersionText = $versionText
+            VersionCore = $versionMatch.Groups['core'].Value
+            VersionSuffix = $versionMatch.Groups['suffix'].Value
+        }
+    }
     
     # Find the first valid release header line.
-    $headerLine = $null
+    $headerData = $null
     $headerLineIndex = -1
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $candidate = Get-LeadingNoiseFreeText -Line $lines[$i]
-
-        if ($candidate.StartsWith('####')) {
-            $headerLine = $candidate
+        $candidate = Get-ReleaseHeaderData -Line $lines[$i]
+        if ($candidate) {
+            $headerData = $candidate
             $headerLineIndex = $i
             break
         }
     }
 
-    if ($null -eq $headerLine) {
+    if ($null -eq $headerData) {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
     # Extract header text, then version/date.
-    $headerLine = $headerLine -replace "^####\s*", ""
-    $headerLine = $headerLine -replace "\s*####\s*$", ""
-
-    $headerParts = $headerLine -split " ", 2
-    $versionText = $headerParts[0]
-
-    if ($versionText -notmatch $versionPattern) {
-        throw "Invalid release version '$versionText' in $MarkdownFile."
-    }
+    $headerParts = $headerData.HeaderParts
+    $versionText = $headerData.VersionText
 
     $outputObject.Version = $versionText
-    $outputObject.VersionCore = $matches.core
-    $outputObject.VersionSuffix = if ($matches.suffix) { $matches.suffix } else { '' }
+    $outputObject.VersionCore = $headerData.VersionCore
+    $outputObject.VersionSuffix = if ($headerData.VersionSuffix) { $headerData.VersionSuffix } else { '' }
 
     if ($headerParts.Count -ge 2) {
         $outputObject.Date = $headerParts[1]
@@ -81,9 +124,7 @@ function Get-ReleaseNotes {
     # Grab release notes from this first section only.
     $releaseNotesEndLine = $lines.Count
     for ($i = $headerLineIndex + 1; $i -lt $lines.Count; $i++) {
-        $candidate = Get-LeadingNoiseFreeText -Line $lines[$i]
-
-        if ($candidate.StartsWith('####')) {
+        if (Get-ReleaseHeaderData -Line $lines[$i]) {
             $releaseNotesEndLine = $i
             break
         }

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -10,11 +10,15 @@ function Get-ReleaseNotes {
     # Split content based on headers
     $sections = $content -split "####"
 
+    $versionPattern = '^(?<core>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))(?:-(?<suffix>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
+
     # Output object to store result
     $outputObject = [PSCustomObject]@{
-        Version       = $null
-        Date          = $null
-        ReleaseNotes  = $null
+        Version      = $null
+        VersionCore  = $null
+        VersionSuffix = $null
+        Date         = $null
+        ReleaseNotes = $null
     }
 
     # Check if we have at least 3 sections (1. Before the header, 2. Header, 3. Release notes)
@@ -24,12 +28,25 @@ function Get-ReleaseNotes {
 
         # Extract version and date from the header
         $headerParts = $header -split " ", 2
-        if ($headerParts.Count -eq 2) {
-            $outputObject.Version = $headerParts[0]
-            $outputObject.Date = $headerParts[1]
+        if ($headerParts.Count -ge 1) {
+            $versionText = $headerParts[0]
+
+            if ($versionText -notmatch $versionPattern) {
+                throw "Invalid release version '$versionText' in $MarkdownFile."
+            }
+
+            $outputObject.Version = $versionText
+            $outputObject.VersionCore = $matches.core
+            $outputObject.VersionSuffix = if ($matches.suffix) { $matches.suffix } else { '' }
+
+            if ($headerParts.Count -ge 2) {
+                $outputObject.Date = $headerParts[1]
+            }
         }
 
         $outputObject.ReleaseNotes = $releaseNotes
+    } else {
+        throw "Unable to parse release notes from $MarkdownFile."
     }
 
     # Return the output object

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -22,14 +22,17 @@ function Get-ReleaseNotes {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
+    $leadingNoisePattern = '^[\p{Z}\p{Cf}\p{Cc}]+'
+    $headerPrefixPattern = '^([\p{Z}\p{Cf}\p{Cc}]*)####\s*'
+    
     # Find the first valid release header line.
     $headerLine = $null
     $headerLineIndex = -1
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $candidate = $lines[$i].Trim()
-        $candidate = [regex]::Replace($candidate, '^[\uFEFF\u200B\u200C\u200D\u2060]+', '')
+        $candidate = [regex]::Replace($lines[$i], $leadingNoisePattern, '')
 
-        if ($candidate.StartsWith('####')) {
+        $headerMatch = [regex]::Match($candidate, $headerPrefixPattern)
+        if ($headerMatch.Success) {
             $headerLine = $candidate
             $headerLineIndex = $i
             break
@@ -46,7 +49,7 @@ function Get-ReleaseNotes {
     }
 
     # Extract header text, then version/date.
-    $headerLine = $headerLine.Substring(4).Trim()
+    $headerLine = $headerLine -replace "^([\p{Z}\p{Cf}\p{Cc}]*)####\s*", ""
     $headerLine = $headerLine -replace "\s*####\s*$", ""
 
     $headerParts = $headerLine -split " ", 2
@@ -67,7 +70,9 @@ function Get-ReleaseNotes {
     # Grab release notes from this first section only.
     $releaseNotesEndLine = $lines.Count
     for ($i = $headerLineIndex + 1; $i -lt $lines.Count; $i++) {
-        if ($lines[$i].Trim().StartsWith("####")) {
+        $candidate = [regex]::Replace($lines[$i], $leadingNoisePattern, '')
+
+        if ([regex]::IsMatch($candidate, $headerPrefixPattern)) {
             $releaseNotesEndLine = $i
             break
         }

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -5,10 +5,7 @@ function Get-ReleaseNotes {
     )
 
     # Read markdown file content
-    $content = Get-Content -Path $MarkdownFile -Raw
-
-    # Split content based on headers
-    $sections = $content -split "####"
+    $lines = Get-Content -Path $MarkdownFile
 
     $versionPattern = '^(?<core>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))(?:-(?<suffix>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
 
@@ -21,32 +18,68 @@ function Get-ReleaseNotes {
         ReleaseNotes = $null
     }
 
-    # Check if we have at least 3 sections (1. Before the header, 2. Header, 3. Release notes)
-    if ($sections.Count -ge 3) {
-        $header = $sections[1].Trim()
-        $releaseNotes = $sections[2].Trim()
+    if (-not $lines -or $lines.Count -eq 0) {
+        throw "Unable to parse release notes from $MarkdownFile."
+    }
 
-        # Extract version and date from the header
-        $headerParts = $header -split " ", 2
-        if ($headerParts.Count -ge 1) {
-            $versionText = $headerParts[0]
+    # Find the first non-empty line to find the latest release header.
+    $headerLine = $null
+    $headerLineIndex = 0
+    while ($headerLineIndex -lt $lines.Count) {
+        $candidate = $lines[$headerLineIndex].Trim()
 
-            if ($versionText -notmatch $versionPattern) {
-                throw "Invalid release version '$versionText' in $MarkdownFile."
-            }
-
-            $outputObject.Version = $versionText
-            $outputObject.VersionCore = $matches.core
-            $outputObject.VersionSuffix = if ($matches.suffix) { $matches.suffix } else { '' }
-
-            if ($headerParts.Count -ge 2) {
-                $outputObject.Date = $headerParts[1]
-            }
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            $headerLine = $candidate
+            break
         }
 
-        $outputObject.ReleaseNotes = $releaseNotes
-    } else {
+        $headerLineIndex++
+    }
+
+    if ($null -eq $headerLine) {
         throw "Unable to parse release notes from $MarkdownFile."
+    }
+
+    # Strip BOMs or other non-content leading chars.
+    $headerLine = $headerLine.TrimStart([char]0xFEFF, [char]0x200B)
+
+    if (-not $headerLine.StartsWith("####")) {
+        throw "Unable to parse release notes from $MarkdownFile."
+    }
+
+    # Extract header text, then version/date.
+    $headerLine = $headerLine.Substring(4).Trim()
+    $headerLine = $headerLine -replace "\s*####\s*$", ""
+
+    $headerParts = $headerLine -split " ", 2
+    $versionText = $headerParts[0]
+
+    if ($versionText -notmatch $versionPattern) {
+        throw "Invalid release version '$versionText' in $MarkdownFile."
+    }
+
+    $outputObject.Version = $versionText
+    $outputObject.VersionCore = $matches.core
+    $outputObject.VersionSuffix = if ($matches.suffix) { $matches.suffix } else { '' }
+
+    if ($headerParts.Count -ge 2) {
+        $outputObject.Date = $headerParts[1]
+    }
+
+    # Grab release notes from this first section only.
+    $releaseNotesEndLine = $lines.Count
+    for ($i = $headerLineIndex + 1; $i -lt $lines.Count; $i++) {
+        if ($lines[$i].Trim().StartsWith("####")) {
+            $releaseNotesEndLine = $i
+            break
+        }
+    }
+
+    if ($releaseNotesEndLine -gt $headerLineIndex + 1) {
+        $outputObject.ReleaseNotes = ($lines[($headerLineIndex + 1)..($releaseNotesEndLine - 1)] -join "`r`n").Trim()
+    }
+    else {
+        $outputObject.ReleaseNotes = ""
     }
 
     # Return the output object

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -22,28 +22,26 @@ function Get-ReleaseNotes {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
-    # Find the first non-empty line to find the latest release header.
+    # Find the first valid release header line.
     $headerLine = $null
-    $headerLineIndex = 0
-    while ($headerLineIndex -lt $lines.Count) {
-        $candidate = $lines[$headerLineIndex].Trim()
+    $headerLineIndex = -1
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $candidate = $lines[$i].Trim()
+        $candidate = [regex]::Replace($candidate, '^[\uFEFF\u200B\u200C\u200D\u2060]+', '')
 
-        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+        if ($candidate.StartsWith('####')) {
             $headerLine = $candidate
+            $headerLineIndex = $i
             break
         }
-
-        $headerLineIndex++
     }
 
     if ($null -eq $headerLine) {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
-    # Strip BOMs or other non-content leading chars.
-    $headerLine = $headerLine.TrimStart([char]0xFEFF, [char]0x200B)
-
-    if (-not $headerLine.StartsWith("####")) {
+    # Safety check after filtering out hidden leading characters.
+    if ($null -eq $headerLine -or -not $headerLine.StartsWith('####')) {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 

--- a/scripts/getReleaseNotes.ps1
+++ b/scripts/getReleaseNotes.ps1
@@ -22,17 +22,33 @@ function Get-ReleaseNotes {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
-    $leadingNoisePattern = '^[\p{Z}\p{Cf}\p{Cc}]+'
-    $headerPrefixPattern = '^([\p{Z}\p{Cf}\p{Cc}]*)####\s*'
+    function Get-LeadingNoiseFreeText {
+        param(
+            [Parameter()]
+            [AllowEmptyString()]
+            [string]$Line
+        )
+
+        while (-not [string]::IsNullOrEmpty($Line)) {
+            $firstCharacter = $Line[0]
+            if ([char]::IsWhiteSpace($firstCharacter) -or [char]::IsControl($firstCharacter) -or [System.Char]::GetUnicodeCategory($firstCharacter) -eq [System.Globalization.UnicodeCategory]::Format) {
+                $Line = $Line.Substring(1)
+                continue
+            }
+
+            break
+        }
+
+        return $Line
+    }
     
     # Find the first valid release header line.
     $headerLine = $null
     $headerLineIndex = -1
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $candidate = [regex]::Replace($lines[$i], $leadingNoisePattern, '')
+        $candidate = Get-LeadingNoiseFreeText -Line $lines[$i]
 
-        $headerMatch = [regex]::Match($candidate, $headerPrefixPattern)
-        if ($headerMatch.Success) {
+        if ($candidate.StartsWith('####')) {
             $headerLine = $candidate
             $headerLineIndex = $i
             break
@@ -43,13 +59,8 @@ function Get-ReleaseNotes {
         throw "Unable to parse release notes from $MarkdownFile."
     }
 
-    # Safety check after filtering out hidden leading characters.
-    if ($null -eq $headerLine -or -not $headerLine.StartsWith('####')) {
-        throw "Unable to parse release notes from $MarkdownFile."
-    }
-
     # Extract header text, then version/date.
-    $headerLine = $headerLine -replace "^([\p{Z}\p{Cf}\p{Cc}]*)####\s*", ""
+    $headerLine = $headerLine -replace "^####\s*", ""
     $headerLine = $headerLine -replace "\s*####\s*$", ""
 
     $headerParts = $headerLine -split " ", 2
@@ -70,9 +81,9 @@ function Get-ReleaseNotes {
     # Grab release notes from this first section only.
     $releaseNotesEndLine = $lines.Count
     for ($i = $headerLineIndex + 1; $i -lt $lines.Count; $i++) {
-        $candidate = [regex]::Replace($lines[$i], $leadingNoisePattern, '')
+        $candidate = Get-LeadingNoiseFreeText -Line $lines[$i]
 
-        if ([regex]::IsMatch($candidate, $headerPrefixPattern)) {
+        if ($candidate.StartsWith('####')) {
             $releaseNotesEndLine = $i
             break
         }


### PR DESCRIPTION
## Summary
- Enforce strict SemVer parsing in release note extraction
- Split release version into VersionCore and VersionSuffix
- Update Directory.Build.props from core/suffix
- Keep ReleaseNotes injection unchanged

## Notes
- Stale prerelease suffixes are no longer carried into stable releases
-  now logs parsed release version and suffix for visibility
