### PR TITLE
Add runtime gallery version display

### DIFF
--- a/src/SkillServer/Endpoints.cs
+++ b/src/SkillServer/Endpoints.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.AspNetCore.Mvc;
+using System.Reflection;
 using System.Text.Json;
 using SkillServer.Data;
 using SkillServer.Models;
@@ -24,10 +25,29 @@ public static class Endpoints
 
     private static void MapV1Api(this WebApplication app)
     {
+        app.MapAppInfoEndpoints();
         app.MapSkillEndpoints();
         app.MapSubAgentEndpoints();
         app.MapBlobEndpoints();
         app.MapApiKeyEndpoints();
+    }
+
+    private static void MapAppInfoEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/v1/info", () =>
+        {
+            var assembly = typeof(Endpoints).Assembly;
+            var assemblyVersion = assembly.GetName().Version?.ToString() ?? "unknown";
+            var version = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? assemblyVersion;
+
+            return Results.Json(new AppInfoResponse
+            {
+                Version = version,
+                AssemblyVersion = assemblyVersion
+            }, SkillServerJsonContext.Default.AppInfoResponse);
+        });
     }
 
     private static void MapDiscoveryEndpoints(this WebApplication app)

--- a/src/SkillServer/Models/ApiModels.cs
+++ b/src/SkillServer/Models/ApiModels.cs
@@ -274,6 +274,15 @@ public sealed record ApiKeySummary
     public DateTimeOffset? ExpiresAt { get; init; }
 }
 
+public sealed record AppInfoResponse
+{
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("assemblyVersion")]
+    public required string AssemblyVersion { get; init; }
+}
+
 /// <summary>
 /// Response from the health check endpoint.
 /// </summary>

--- a/src/SkillServer/Models/SkillServerJsonContext.cs
+++ b/src/SkillServer/Models/SkillServerJsonContext.cs
@@ -30,6 +30,7 @@ namespace SkillServer.Models;
 [JsonSerializable(typeof(CreateApiKeyResponse))]
 [JsonSerializable(typeof(ApiKeySummary))]
 [JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
+[JsonSerializable(typeof(AppInfoResponse))]
 [JsonSerializable(typeof(IReadOnlyList<CheckUpdateRequestItem>))]
 [JsonSerializable(typeof(IReadOnlyList<CheckUpdateResponseItem>))]
 [JsonSerializable(typeof(HealthResponse))]

--- a/src/SkillServer/wwwroot/js/api.js
+++ b/src/SkillServer/wwwroot/js/api.js
@@ -6,6 +6,12 @@
 
 const API_BASE = '/api/v1';
 
+export async function fetchAppInfo() {
+    const res = await fetch(`${API_BASE}/info`);
+    if (!res.ok) throw new Error(`Failed to fetch app info: ${res.status}`);
+    return res.json();
+}
+
 export async function fetchSkills(query, skip, take) {
     const params = new URLSearchParams();
     if (query) params.set('q', query);

--- a/src/SkillServer/wwwroot/js/footer.js
+++ b/src/SkillServer/wwwroot/js/footer.js
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="footer.js" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+import { fetchAppInfo } from './api.js';
+
+export async function renderAppVersion() {
+    const targets = document.querySelectorAll('[data-app-version-label]');
+    if (targets.length === 0) return;
+
+    try {
+        const info = await fetchAppInfo();
+        const version = info.version || info.assemblyVersion;
+        if (!version) return;
+
+        targets.forEach(target => {
+            target.textContent = `SkillServer v${version}`;
+        });
+    } catch {
+        // Leave the static fallback intact when the runtime endpoint is unavailable.
+    }
+}

--- a/src/SkillServer/wwwroot/skills/index.html
+++ b/src/SkillServer/wwwroot/skills/index.html
@@ -39,13 +39,16 @@
       <span>·</span>
       <a href="https://github.com/netclaw-dev">GitHub</a>
     </div>
-    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+    <div class="footer-version"><span data-app-version-label>SkillServer</span> · Self-hosted agent infrastructure</div>
   </div>
 </footer>
 
 <script type="module">
 import { fetchSkills, fetchSkillVersions, fetchSkillMd } from '/js/api.js';
+import { renderAppVersion } from '/js/footer.js';
 import { getSkillName, getSkillVersion } from '/js/router.js';
+
+renderAppVersion();
 
 const app = document.getElementById('app');
 const skillName = getSkillName();

--- a/src/SkillServer/wwwroot/subagents/index.html
+++ b/src/SkillServer/wwwroot/subagents/index.html
@@ -39,13 +39,16 @@
       <span>·</span>
       <a href="https://github.com/netclaw-dev">GitHub</a>
     </div>
-    <div class="footer-version">SkillServer v0.5.0 · Self-hosted agent infrastructure</div>
+    <div class="footer-version"><span data-app-version-label>SkillServer</span> · Self-hosted agent infrastructure</div>
   </div>
 </footer>
 
 <script type="module">
 import { fetchSubAgents, fetchSubAgentVersions, fetchAgentMd } from '/js/api.js';
+import { renderAppVersion } from '/js/footer.js';
 import { getSubAgentName } from '/js/router.js';
+
+renderAppVersion();
 
 const app = document.getElementById('app');
 const agentName = getSubAgentName();

--- a/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
+++ b/tests/SkillServer.Integration.Tests/SkillServerIntegrationTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.IO.Compression;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -56,6 +57,24 @@ public sealed class SkillServerIntegrationTests
         Assert.NotNull(body);
         Assert.Equal("healthy", body.Status);
         Assert.True(body.Timestamp > DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public async Task AppInfo_ReturnsAssemblyVersion()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var assembly = typeof(Program).Assembly;
+        var expectedAssemblyVersion = assembly.GetName().Version?.ToString() ?? "unknown";
+        var expectedVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? expectedAssemblyVersion;
+
+        var body = await _fixture.HttpClient.GetFromJsonAsync<SkillServer.Models.AppInfoResponse>(
+            "/api/v1/info", ct);
+
+        Assert.NotNull(body);
+        Assert.Equal(expectedVersion, body.Version);
+        Assert.Equal(expectedAssemblyVersion, body.AssemblyVersion);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expose SkillServer assembly version via /api/v1/info
- render gallery footer version from runtime app metadata
- cover the app info endpoint with an integration test

## Verification
- dotnet build -c Release
- dotnet test -c Release
- pwsh -File scripts/Add-FileHeaders.ps1 -Verify
- dotnet slopwatch analyze