### PR TITLE
Add list-subagents and delete-subagent CLI commands

### DIFF
--- a/src/Netclaw.SkillServer.Cli/Commands/DeleteSubAgentCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/DeleteSubAgentCommand.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeleteSubAgentCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Output;
+
+namespace Netclaw.SkillServer.Cli.Commands;
+
+internal static class DeleteSubAgentCommand
+{
+    public static async Task<int> ExecuteAsync(ParsedArgs args, SkillServerClient client)
+    {
+        if (args.Help || args.Positional.Count < 2)
+        {
+            PrintHelp();
+            return args.Help ? 0 : 1;
+        }
+
+        var name = args.Positional[0];
+        var version = args.Positional[1];
+
+        if (!args.Yes)
+        {
+            Console.Write($"Delete sub-agent {name}@{version}? [y/N]: ");
+            var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+            if (response is not "y" and not "yes")
+            {
+                ConsoleOutput.WriteInfo("Cancelled.");
+                return 0;
+            }
+        }
+
+        try
+        {
+            await client.DeleteSubAgentVersionAsync(name, version);
+            ConsoleOutput.WriteSuccess($"Deleted sub-agent {name}@{version}");
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConsoleOutput.HandleHttpError(ex);
+        }
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: skillserver delete-subagent <name> <version> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Delete a published sub-agent version.");
+        Console.WriteLine();
+        Console.WriteLine("Arguments:");
+        Console.WriteLine("  <name>                Sub-agent name");
+        Console.WriteLine("  <version>             Version to delete");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --yes, -y             Skip confirmation prompt");
+    }
+}

--- a/src/Netclaw.SkillServer.Cli/Commands/ListSubAgentsCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/ListSubAgentsCommand.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="ListSubAgentsCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Json;
+using Netclaw.SkillServer.Cli.Output;
+
+namespace Netclaw.SkillServer.Cli.Commands;
+
+internal static class ListSubAgentsCommand
+{
+    public static async Task<int> ExecuteAsync(ParsedArgs args, SkillServerClient client)
+    {
+        if (args.Help)
+        {
+            PrintHelp();
+            return 0;
+        }
+
+        var subAgents = await client.ListSubAgentsAsync();
+
+        if (args.OutputFormat == "json")
+        {
+            var json = JsonSerializer.Serialize(subAgents, CliJsonContext.Default.IReadOnlyListSubAgentSummary);
+            Console.WriteLine(json);
+            return 0;
+        }
+
+        if (subAgents.Count == 0)
+        {
+            ConsoleOutput.WriteInfo("No sub-agents found.");
+            return 0;
+        }
+
+        var headers = new[] { "NAME", "LATEST", "VERSIONS", "UPDATED" };
+        var rows = subAgents.Select(s => new[]
+        {
+            s.Name,
+            s.LatestVersion,
+            s.VersionCount.ToString(),
+            s.UpdatedAt.ToString("yyyy-MM-dd")
+        }).ToList();
+
+        ConsoleOutput.WriteTable(headers, rows);
+        return 0;
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: skillserver list-subagents [options]");
+        Console.WriteLine();
+        Console.WriteLine("List sub-agents on the server.");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --output <text|json>  Output format (default: text)");
+    }
+}

--- a/src/Netclaw.SkillServer.Cli/Json/CliJsonContext.cs
+++ b/src/Netclaw.SkillServer.Cli/Json/CliJsonContext.cs
@@ -13,6 +13,7 @@ namespace Netclaw.SkillServer.Cli.Json;
 [JsonSerializable(typeof(CliConfig))]
 [JsonSerializable(typeof(IReadOnlyList<SkillSummary>))]
 [JsonSerializable(typeof(IReadOnlyList<SkillVersionSummary>))]
+[JsonSerializable(typeof(IReadOnlyList<SubAgentSummary>))]
 [JsonSerializable(typeof(IReadOnlyList<ApiKeySummary>))]
 [JsonSerializable(typeof(SkillUploadResponse))]
 [JsonSerializable(typeof(ErrorResponse))]

--- a/src/Netclaw.SkillServer.Cli/Program.cs
+++ b/src/Netclaw.SkillServer.Cli/Program.cs
@@ -53,7 +53,7 @@ if (parsedArgs.Help)
 var resolver = new ConfigResolver();
 var config = resolver.Resolve(parsedArgs.ServerUrl, parsedArgs.ApiKey);
 
-var requiresAuth = parsedArgs.Command is not "list" and not "versions" and not "verify" and not "download-subagent";
+var requiresAuth = parsedArgs.Command is not "list" and not "list-subagents" and not "versions" and not "verify" and not "download-subagent";
 
 if (!config.HasServerUrl)
 {
@@ -82,7 +82,9 @@ static async Task<int> DispatchAsync(ParsedArgs parsedArgs, SkillServerClient cl
         "download-subagent" => await DownloadSubAgentCommand.ExecuteAsync(parsedArgs, client),
         "publish-all" => await PublishAllCommand.ExecuteAsync(parsedArgs, client),
         "delete" => await DeleteCommand.ExecuteAsync(parsedArgs, client),
+        "delete-subagent" => await DeleteSubAgentCommand.ExecuteAsync(parsedArgs, client),
         "list" => await ListCommand.ExecuteAsync(parsedArgs, client),
+        "list-subagents" => await ListSubAgentsCommand.ExecuteAsync(parsedArgs, client),
         "versions" => await VersionsCommand.ExecuteAsync(parsedArgs, client),
         "verify" => await VerifyCommand.ExecuteAsync(parsedArgs, client),
         "api-key" => await ApiKeyCommand.ExecuteAsync(parsedArgs, client),
@@ -127,7 +129,9 @@ static void PrintHelp()
     Console.WriteLine("  publish-all <path>        Batch-publish all skills in a directory");
     Console.WriteLine("  lint <path>               Validate skills or sub-agents (no auth required)");
     Console.WriteLine("  delete <name> <version>   Delete a published skill version");
+    Console.WriteLine("  delete-subagent <n> <v>   Delete a published sub-agent version");
     Console.WriteLine("  list                      List skills on the server");
+    Console.WriteLine("  list-subagents            List sub-agents on the server");
     Console.WriteLine("  versions <name>           List all versions of a skill");
     Console.WriteLine("  verify <path>             Verify local skill matches published version");
     Console.WriteLine("  config                    Manage CLI configuration");

--- a/src/Netclaw.SkillServer.Cli/README.md
+++ b/src/Netclaw.SkillServer.Cli/README.md
@@ -101,6 +101,12 @@ skillserver versions my-skill
 
 # JSON output
 skillserver list --output json
+
+# List all sub-agents
+skillserver list-subagents
+
+# Sub-agents as JSON
+skillserver list-subagents --output json
 ```
 
 ### Verification
@@ -141,6 +147,12 @@ skillserver delete my-skill 1.0.0
 
 # Skip confirmation
 skillserver delete my-skill 1.0.0 --yes
+
+# Delete a sub-agent version (with confirmation prompt)
+skillserver delete-subagent support-agent 1.0.0
+
+# Skip confirmation
+skillserver delete-subagent support-agent 1.0.0 --yes
 ```
 
 ### API Key Management

--- a/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/CliArgsParserTests.cs
@@ -155,6 +155,16 @@ public sealed class CliArgsParserTests
     }
 
     [Fact]
+    public void Parse_ListSubAgentsCommand_WithJsonOutput()
+    {
+        var result = CliArgsParser.Parse(["list-subagents", "--output", "json"]);
+
+        Assert.Equal("list-subagents", result.Command);
+        Assert.Equal("json", result.OutputFormat);
+        Assert.Empty(result.Positional);
+    }
+
+    [Fact]
     public void Parse_DeleteCommand_WithArgs()
     {
         var result = CliArgsParser.Parse(["delete", "my-skill", "1.0.0", "--yes"]);
@@ -162,6 +172,18 @@ public sealed class CliArgsParserTests
         Assert.Equal("delete", result.Command);
         Assert.Equal(2, result.Positional.Count);
         Assert.Equal("my-skill", result.Positional[0]);
+        Assert.Equal("1.0.0", result.Positional[1]);
+        Assert.True(result.Yes);
+    }
+
+    [Fact]
+    public void Parse_DeleteSubAgentCommand_WithArgs()
+    {
+        var result = CliArgsParser.Parse(["delete-subagent", "support-agent", "1.0.0", "--yes"]);
+
+        Assert.Equal("delete-subagent", result.Command);
+        Assert.Equal(2, result.Positional.Count);
+        Assert.Equal("support-agent", result.Positional[0]);
         Assert.Equal("1.0.0", result.Positional[1]);
         Assert.True(result.Yes);
     }

--- a/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/ProgramDispatchTests.cs
@@ -96,6 +96,45 @@ public sealed class ProgramDispatchTests : IDisposable
         Assert.Contains("Server URL not configured", result.StdErr);
     }
 
+    [Fact]
+    public async Task ListSubAgents_RequiresServerUrl()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var result = await RunCliAsync(["list-subagents"], ct);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Server URL not configured", result.StdErr);
+    }
+
+    [Fact]
+    public async Task ListSubAgents_DoesNotRequireApiKey()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // list-subagents mirrors 'list': a server URL is required, but no API key.
+        // With only a server URL set, the CLI must not short-circuit on missing auth.
+        var result = await RunCliAsync(
+            ["list-subagents", "--server-url", "http://127.0.0.1:59999"], ct);
+
+        Assert.DoesNotContain("Authentication required", result.StdErr);
+        Assert.DoesNotContain("Authentication required", result.StdOut);
+    }
+
+    [Fact]
+    public async Task DeleteSubAgent_RequiresApiKey()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // delete-subagent mirrors 'delete': it is an authenticated write operation.
+        var result = await RunCliAsync(
+            ["delete-subagent", "support-agent", "1.0.0", "--yes", "--server-url", "http://127.0.0.1:59999"],
+            ct);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Authentication required", result.StdErr);
+    }
+
     private static async Task<CliResult> RunCliAsync(string[] args, CancellationToken ct)
     {
         var dllPath = typeof(LintCommand).Assembly.Location;


### PR DESCRIPTION
## Summary

Adds the two missing sub-agent management commands to the `skillserver` CLI, bringing it to parity with the skill commands and with the SkillServer HTTP API + `Netclaw.SkillClient`, which already expose full sub-agent list/delete support.

- `list-subagents` -> `GET /subagents/` (supports `--output json`, no auth required, mirroring `list`)
- `delete-subagent <name> <version>` -> `DELETE /subagents/{name}/{version}` (API-key authenticated, mirroring `delete`)

Previously the CLI wrapped only the skill side (`list`, `delete`, `versions`) plus the sub-agent publish/download commands, but had no way to enumerate or remove published sub-agents.

## Changes

- New `ListSubAgentsCommand` and `DeleteSubAgentCommand`, mirroring `ListCommand`/`DeleteCommand` (confirmation prompt, `--yes`, HTTP error handling).
- Wire both into `Program.cs` dispatch; add `list-subagents` to the no-auth allowlist alongside `list`.
- Add `IReadOnlyList<SubAgentSummary>` to the source-generated `CliJsonContext` for trim-safe JSON output.
- Update `--help`/usage text and the CLI `README.md`.
- Reuses the existing HTTP client, auth gating, and output-formatting helpers (`SkillServerClient.ListSubAgentsAsync` / `DeleteSubAgentVersionAsync` already existed).

## Testing

- `dotnet build` clean (0 warnings; repo uses `TreatWarningsAsErrors`).
- `dotnet test` (CLI test project) green — 112 tests.
- New parser tests (`Parse_ListSubAgentsCommand_WithJsonOutput`, `Parse_DeleteSubAgentCommand_WithArgs`) and dispatch/auth tests (`ListSubAgents_RequiresServerUrl`, `ListSubAgents_DoesNotRequireApiKey`, `DeleteSubAgent_RequiresApiKey`) mirror the existing skill list/delete tests.
- Slopwatch clean; trimmed single-file `linux-x64` publish passes the trim-warning-as-error gate; smoke-tested the trimmed binary (`--help`, `list-subagents`, `delete-subagent`).

https://claude.ai/code/session_01VYvvEehJtr1uEVFHxzjg7P
