### PR TITLE
Release 0.4.0-beta.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,17 +20,11 @@
   </PropertyGroup>
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.4.0-beta.5</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>0.4.0-beta.6</VersionPrefix>
+    <VersionSuffix>
+    </VersionSuffix>
     <PackageReleaseNotes>**New Features**
-- Add gallery resource browser — expose skill resource metadata and render a read-only file browser in the gallery for SKILL.md and resource files
-- Add runtime gallery version display — expose SkillServer assembly metadata through `/api/v1/info` and render gallery footer versions from runtime app metadata
-
-**Bug Fixes**
-- Fix `?q=` query param not being read on skills listing page — navigating from homepage search to `/skills/?q=foo` now pre-fills the search box, shows filtered results, and updates the heading to 'Search Results' (#124)
-
-**Internal**
-- Remove duplicate `release_notes.md` (lowercase variant) to prevent checkout conflicts on case-insensitive filesystems (Windows)</PackageReleaseNotes>
+- Add `list-subagents` and `delete-subagent` CLI commands to enumerate and remove published sub-agent versions, bringing the `skillserver` CLI to parity with the existing skill `list`/`delete` commands (#129)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 0.4.0-beta.6 July 10th 2026 ####
+
+**New Features**
+- Add `list-subagents` and `delete-subagent` CLI commands to enumerate and remove published sub-agent versions, bringing the `skillserver` CLI to parity with the existing skill `list`/`delete` commands (#129)
+
 #### 0.4.0-beta.5 July 8th 2026 ####
 
 **New Features**


### PR DESCRIPTION
## Summary

Cuts prerelease **0.4.0-beta.6**.

Bumps `VersionPrefix` and updates `RELEASE_NOTES.md` / `PackageReleaseNotes` for the new release, following the established release-PR convention.

### Included since 0.4.0-beta.5

**New Features**
- Add `list-subagents` and `delete-subagent` CLI commands to enumerate and remove published sub-agent versions, bringing the `skillserver` CLI to parity with the existing skill `list`/`delete` commands (#129)

## Release process

After merge, tag `0.4.0-beta.6` on `dev` to trigger the `release.yml` workflow (NuGet push, CLI binaries, GHCR container, and a GitHub prerelease — the tag contains `-` so it is marked prerelease and the `latest` container tag is skipped).

https://claude.ai/code/session_01VYvvEehJtr1uEVFHxzjg7P
