### PR TITLE
Add copy button to code blocks on skills and sub-agents pages

### DIFF
--- a/src/SkillServer/wwwroot/script.js
+++ b/src/SkillServer/wwwroot/script.js
@@ -1,5 +1,9 @@
-function copyToClipboard(btn, elementId) {
-  var text = document.getElementById(elementId).textContent;
+function copyToClipboard(btn) {
+  var header = btn.closest('.file-preview-header');
+  var wrap = btn.closest('.code-block-wrap');
+  var codeBlock = header ? header.nextElementSibling : wrap ? wrap.querySelector('.code-block') : null;
+  if (!codeBlock) return;
+  var text = codeBlock.textContent;
   navigator.clipboard.writeText(text).then(function() {
     var orig = btn.innerHTML;
     btn.classList.add('copied');

--- a/src/SkillServer/wwwroot/skills/index.html
+++ b/src/SkillServer/wwwroot/skills/index.html
@@ -277,7 +277,13 @@ function renderTextPreview(file, content) {
                 <div class="file-preview-title">${escapeHtml(file.path)}</div>
                 <div class="file-preview-subtitle">${escapeHtml(file.contentType || 'text/plain')}</div>
             </div>
-            <div class="file-preview-meta">${file.language ? escapeHtml(file.language) : 'text'} · ${formatBytes(file.sizeBytes)}</div>
+            <div style="display:flex;align-items:center;gap:12px;">
+                <div class="file-preview-meta">${file.language ? escapeHtml(file.language) : 'text'} · ${formatBytes(file.sizeBytes)}</div>
+                <button class="copy-btn" onclick="copyToClipboard(this)" title="Copy to clipboard">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                    Copy
+                </button>
+            </div>
         </div>
         <div class="code-block file-code"><pre><code class="language-${escapeAttribute(file.language || 'text')}">${escapeHtml(content)}</code></pre></div>
     `;
@@ -331,6 +337,23 @@ function escapeAttribute(str) {
         .replaceAll('"', '&quot;')
         .replaceAll('<', '&lt;')
         .replaceAll('>', '&gt;');
+}
+
+window.copyToClipboard = function(btn) {
+    var header = btn.closest('.file-preview-header');
+    var wrap = btn.closest('.code-block-wrap');
+    var codeBlock = header ? header.nextElementSibling : wrap ? wrap.querySelector('.code-block') : null;
+    if (!codeBlock) return;
+    var text = codeBlock.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+        var orig = btn.innerHTML;
+        btn.classList.add('copied');
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+        setTimeout(function() {
+            btn.classList.remove('copied');
+            btn.innerHTML = orig;
+        }, 2000);
+    });
 }
 </script>
 

--- a/src/SkillServer/wwwroot/style.css
+++ b/src/SkillServer/wwwroot/style.css
@@ -146,6 +146,11 @@ a:hover{color:var(--teal-dark)}
 .code-block .string{color:var(--teal)}
 .code-block .title{color:var(--text)}
 
+/* ── CODE BLOCK WRAP (for standalone code blocks with toolbar) ── */
+.code-block-wrap{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.code-block-wrap .code-block{border:0;border-radius:0}
+.code-block-toolbar{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;border-bottom:1px solid var(--border)}
+
 /* ── FILE BROWSER ── */
 .file-browser{display:grid;grid-template-columns:minmax(240px,320px) minmax(0,1fr);gap:16px;align-items:start}
 .file-tree{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:8px;max-height:620px;overflow:auto}

--- a/src/SkillServer/wwwroot/subagents/index.html
+++ b/src/SkillServer/wwwroot/subagents/index.html
@@ -111,7 +111,16 @@ async function renderDetail(name) {
                 <div class="section-header">
                     <h2>agent.md</h2>
                 </div>
-                <div class="code-block"><pre>${escapeHtml(agentMd)}</pre></div>
+                <div class="code-block-wrap">
+                    <div class="code-block-toolbar">
+                        <span class="file-preview-meta">markdown</span>
+                        <button class="copy-btn" onclick="copyToClipboard(this)" title="Copy to clipboard">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            Copy
+                        </button>
+                    </div>
+                    <div class="code-block"><pre>${escapeHtml(agentMd)}</pre></div>
+                </div>
             </section>
             <section class="section">
                 <div class="section-header">
@@ -170,6 +179,23 @@ function escapeHtml(str) {
     const div = document.createElement('div');
     div.textContent = str;
     return div.innerHTML;
+}
+
+window.copyToClipboard = function(btn) {
+    var header = btn.closest('.file-preview-header');
+    var wrap = btn.closest('.code-block-wrap');
+    var codeBlock = header ? header.nextElementSibling : wrap ? wrap.querySelector('.code-block') : null;
+    if (!codeBlock) return;
+    var text = codeBlock.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+        var orig = btn.innerHTML;
+        btn.classList.add('copied');
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+        setTimeout(function() {
+            btn.classList.remove('copied');
+            btn.innerHTML = orig;
+        }, 2000);
+    });
 }
 </script>
 


### PR DESCRIPTION
Copy button added to code blocks on both skills and sub-agents detail pages.

**Skills detail** — Copy button sits in the file preview header next to language/size metadata.

**Sub-agents detail** — Copy button sits in a toolbar above the agent.md code block.

**Changes:**
- `skills/index.html`: Copy button in `renderTextPreview` + `window.copyToClipboard`
- `subagents/index.html`: Code block wrapped in `.code-block-wrap` with toolbar, copy button + `window.copyToClipboard`
- `style.css`: `.code-block-wrap` and `.code-block-toolbar` styles
- `script.js`: Updated shared `copyToClipboard` to work with both layouts

Fixes the scoping issue where inline `onclick` couldn't reach functions inside `<script type="module">` by attaching to `window`.