### PR TITLE
fix(cli): handle 404 in versions command instead of crashing

### DIFF
--- a/src/Netclaw.SkillServer.Cli/Commands/VersionsCommand.cs
+++ b/src/Netclaw.SkillServer.Cli/Commands/VersionsCommand.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Net;
 using System.Text.Json;
 using Netclaw.SkillClient;
 using Netclaw.SkillServer.Cli.Json;
@@ -22,7 +23,21 @@ internal static class VersionsCommand
         }
 
         var name = args.Positional[0];
-        var versions = await client.GetSkillVersionsAsync(name);
+
+        IReadOnlyList<SkillVersionSummary> versions;
+        try
+        {
+            versions = await client.GetSkillVersionsAsync(name);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            ConsoleOutput.WriteError($"Skill '{name}' not found.");
+            return 1;
+        }
+        catch (HttpRequestException ex)
+        {
+            return ConsoleOutput.HandleHttpError(ex);
+        }
 
         if (args.OutputFormat == "json")
         {

--- a/tests/Netclaw.SkillServer.Cli.Tests/VersionsCommandTests.cs
+++ b/tests/Netclaw.SkillServer.Cli.Tests/VersionsCommandTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="VersionsCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.SkillClient;
+using Netclaw.SkillServer.Cli.Commands;
+using Xunit;
+
+namespace Netclaw.SkillServer.Cli.Tests;
+
+public sealed class VersionsCommandTests
+{
+    [Fact]
+    public async Task ExecuteAsync_MissingSkill_ReturnsOneWithoutThrowing()
+    {
+        // Server returns 404 for a skill that isn't published (regression test for #142).
+        var handler = new QueuedHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var client = CreateClient(handler);
+
+        var exitCode = await VersionsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["no-such-skill"] },
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExistingSkill_ReturnsZeroAndListsVersions()
+    {
+        var versions = new[]
+        {
+            new SkillVersionSummary
+            {
+                Name = "example-skill",
+                Version = "1.0.0",
+                Sha256 = "abc123",
+                PublishedAt = DateTimeOffset.UtcNow,
+                IsLatest = true
+            }
+        };
+        var json = JsonSerializer.Serialize(
+            (IReadOnlyList<SkillVersionSummary>)versions,
+            SkillServerClientJsonContext.Default.IReadOnlyListSkillVersionSummary);
+        var handler = new QueuedHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        using var client = CreateClient(handler);
+
+        var exitCode = await VersionsCommand.ExecuteAsync(
+            new ParsedArgs { Positional = ["example-skill"] },
+            client);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    private static SkillServerClient CreateClient(HttpMessageHandler handler)
+    {
+        return new SkillServerClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.test/")
+        });
+    }
+
+    private sealed class QueuedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public QueuedHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri?.AbsolutePath ?? "");
+
+            return Task.FromResult(_responses.Count == 0
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                : _responses.Dequeue());
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`skillserver versions <name>` for a skill that isn't on the server crashed with an unhandled `HttpRequestException` on the server's 404 (`Aborted (core dumped)`, exit `134`), dumping a stack trace.

`VersionsCommand.ExecuteAsync` calls `client.GetSkillVersionsAsync(name)`, which uses `GetFromJsonAsync`. That helper calls `EnsureSuccessStatusCode()` internally and throws `HttpRequestException` on a 404. Nothing caught it, so the process aborted. Sibling read commands (`verify`, `download-subagent`) already wrap their calls in a `try/catch (HttpRequestException)`; `versions` was the outlier.

## Fix

Catch `HttpRequestException` in `VersionsCommand`, matching the sibling pattern:

- A 404 prints a clean `Skill '<name>' not found.` and exits `1`.
- Any other `HttpRequestException` falls through to `ConsoleOutput.HandleHttpError`, exiting `1`.

The fix is scoped to the `versions` path. `SkillServerClient` is unchanged, so `verify` and `download-subagent` are unaffected.

Added `VersionsCommandTests` with two cases using the existing mock-`HttpMessageHandler` pattern: a 404 returns `1` without throwing (regression test for this bug), and a successful response returns `0` and lists versions.

## Verification

Built the CLI from this branch and ran it against a real `ghcr.io/netclaw-dev/skillserver:0.4.0` server.

Missing skill — now exits `1` with a readable message, no stack trace / no core dump:

```
$ skillserver versions no-such-skill
Skill 'no-such-skill' not found.
exit=1
```

Existing skill — still lists versions correctly (exit `0`):

```
$ skillserver publish .../hello-greeter
Published hello-greeter@1.0.0

$ skillserver versions hello-greeter
VERSION  PUBLISHED   LATEST  SHA256
1.0.0    2026-07-22  *       sha256:37e4bb27...
exit=0
```

Sibling commands still behave (exit `1`, no crash) — client untouched, no regression:

```
$ skillserver verify .../k8s-log-triage        # not published to server
Error: Response status code does not indicate success: 404 (Not Found).
exit=1

$ skillserver download-subagent no-such-agent 1.0.0 out.md
Error: Response status code does not indicate success: 404 (Not Found).
exit=1
```

`dotnet build` (Release): 0 warnings, 0 errors. `dotnet test` (CLI test project): 114 passed, 0 failed.

Closes #142
