### PR TITLE
Release 0.4.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,28 +20,12 @@
   </PropertyGroup>
   <!-- Version Management -->
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
-    <PackageReleaseNotes>**What's New**
-
-This release adds a fully interactive gallery UI, first-class sub-agent support, and native manifest endpoints for destination-agnostic skill sync.
-
-**New Features**
-- Add interactive gallery UI with client-side search, skill version history navigation, and a resource browser for viewing SKILL.md and resource files
-- Add first-class sub-agent support — storage endpoints, CLI commands (`publish-subagent`, `list-subagents`, `delete-subagent`, `download-subagent`, `lint subagent`), and batch publishing
-- Add native manifest endpoints (`/manifest.json` and linked documents) for RFC-compatible skill and sub-agent sync
-- Add deterministic `archive.zip` downloads for resourceful skills
-- Add API versioning and native manifest client support in `Netclaw.SkillClient`
-- Add copy button to code blocks in the gallery
-
-**Improvements**
-- Improve skill search relevance with exact and prefix name matching prioritized over description-only matches
-- Preserve executable permission bits (Unix mode) for skill resources in downloaded archives
-
-**Security**
-- Resolve CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc by pinning `Microsoft.OpenApi` to 2.7.5 (#104)
-- Resolve GHSA-hv8m-jj95-wg3x (MessagePack/StreamJsonRpc LZ4 decompression DoS) by upgrading MessagePack to 3.1.8</PackageReleaseNotes>
+    <PackageReleaseNotes>**Bug Fixes**
+- Fix CLI `versions` command crashing with a 404 when a skill has no published versions — now returns gracefully (#143)
+- Fix Docker quick-start compose configuration so it runs as non-root against a writable `/data` volume (#141)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- Default: non-packable unless explicitly set -->
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 0.4.1 July 22nd 2026 ####
+
+**Bug Fixes**
+- Fix CLI `versions` command crashing with a 404 when a skill has no published versions — now returns gracefully (#143)
+- Fix Docker quick-start compose configuration so it runs as non-root against a writable `/data` volume (#141)
+
 #### 0.4.0 July 14th 2026 ####
 
 **What's New**


### PR DESCRIPTION
Two bug fixes since 0.4.0:

- **Fix CLI `versions` command 404 crash** — when a skill has no published versions, the versions command now returns gracefully instead of crashing (#143)
- **Fix Docker compose permissions** — quick-start compose now runs as non-root against a writable `/data` volume (#141)